### PR TITLE
Load full corporate actions data client-side if Pro user

### DIFF
--- a/components/Actions/ActionsPaywall.tsx
+++ b/components/Actions/ActionsPaywall.tsx
@@ -1,20 +1,23 @@
 import { Button } from 'components/Button';
+import { authState } from 'state/authState';
 
-export const ActionsPaywall = ({
-	total,
-	title,
-}: {
-	total: number;
+interface Props {
+	count: number;
+	fullCount: number;
 	title: string;
-}) => {
-	if (total < 100) {
+}
+
+export const ActionsPaywall = ({ count, fullCount, title }: Props) => {
+	const isPro = authState((state) => state.isPro);
+
+	if (isPro || count === fullCount) {
 		return null;
 	}
 
 	return (
 		<div className="border border-gray-200 mt-7 p-6 text-center">
 			<h4 className="text-2xl xs:text-3xl font-bold text-gray-900 mb-3">
-				Showing 100 of {total} {title.toLowerCase()}
+				Showing {count} of {fullCount} {title.toLowerCase()}
 			</h4>
 			<div className="text-xl">Subscribe to see the full list</div>
 			<Button

--- a/components/Actions/actions.types.ts
+++ b/components/Actions/actions.types.ts
@@ -12,7 +12,10 @@ export type CellString = {
 
 export interface ActionProps {
 	year?: string;
-	data: Action[];
+	data: {
+		data: Action[];
+		fullCount: number;
+	};
 }
 
 export interface ActionStatisticsProps {

--- a/components/Ads/Dianomi/FootHorz.tsx
+++ b/components/Ads/Dianomi/FootHorz.tsx
@@ -21,12 +21,8 @@ export const FooterDianomi = () => {
 	) {
 		return (
 			<>
-				<div className="max-w-[970px] min-h-[250px] mx-auto my-9 px-3 xs:px-4 lg:px-0">
-					<div
-						className="dianomi_context"
-						data-dianomi-context-id="443"
-					></div>
-				</div>
+				{/* prettier-ignore */}
+				<div className="max-w-[970px] min-h-[250px] mx-auto my-9 px-3 xs:px-4 lg:px-0"><div className="dianomi_context" data-dianomi-context-id="443"></div></div>
 			</>
 		);
 	}

--- a/components/Ads/GPT/Sidebar1.tsx
+++ b/components/Ads/GPT/Sidebar1.tsx
@@ -15,8 +15,9 @@ export const Sidebar1 = () => {
 	}
 
 	return (
-		<div className="min-h-[250px] mt-3">
-			<div className="dianomi_context" data-dianomi-context-id="420"></div>
-		</div>
+		<>
+			{/* prettier-ignore */}
+			<div className="min-h-[250px] mt-3"><div className="dianomi_context" data-dianomi-context-id="420"></div></div>
+		</>
 	);
 };

--- a/components/FinancialTable/_FinancialTable.tsx
+++ b/components/FinancialTable/_FinancialTable.tsx
@@ -27,6 +27,7 @@ import dynamic from 'next/dynamic';
 import { Tooltip } from './Tooltip';
 import { TooltipChart } from './TooltipChart';
 import { getValidCount } from './functions/getValidCount';
+import { Unavailable } from 'components/Unavailable';
 
 const HoverChart = dynamic(() => import('./HoverChart'), { ssr: false });
 
@@ -74,10 +75,13 @@ export const FinancialTable = ({ statement, financials, info, map }: Props) => {
 			<>
 				<div className="">
 					<TableTitle statement={statement} />
-					<span className="text-xl">
-						No {range} {statement.replace(/_/g, ' ')} data found for this
-						stock.
-					</span>
+					<Unavailable
+						message={`No ${range} ${statement.replace(
+							/_/g,
+							' '
+						)} data found for this stock.`}
+						classes="min-h-[300px] lg:min-h-[500px]"
+					/>
 				</div>
 			</>
 		);

--- a/components/Unavailable.tsx
+++ b/components/Unavailable.tsx
@@ -6,8 +6,8 @@ interface UnavailableI {
 
 export const Unavailable = ({ message, small, classes }: UnavailableI) => (
 	<div
-		className={`h-full flex justify-center items-center text-center p-4 md:p-12 bg-gray-50 border border-gray-200 ${
-			small ? 'text-xl' : 'text-3xl'
+		className={`h-full flex justify-center items-center text-center p-6 md:p-12 bg-gray-50 border border-gray-200 ${
+			small ? 'text-lg md:text-xl' : 'text-xl md:text-2xl'
 		} font-semibold rounded-sm${classes ? ' ' + classes : ''}`}
 	>
 		{message}

--- a/functions/callBackEnd.ts
+++ b/functions/callBackEnd.ts
@@ -50,10 +50,19 @@ export async function getIpoData(query: string) {
 	return response;
 }
 
-export async function getActionsData(query: string, year?: string) {
-	const response = year
-		? await getData(`actions?q=${query}&y=${year}`)
-		: await getData(`actions?q=${query}`);
-	// const response = await getData(`actions?q=${query}`);
+export async function getActionsData(
+	query: string,
+	year?: string,
+	key?: string
+) {
+	const url =
+		year && key
+			? `actions?q=${query}&y=${year}&f=${key}`
+			: year
+			? `actions?q=${query}&y=${year}`
+			: `actions?q=${query}`;
+
+	const response = await getData(url);
+
 	return response;
 }

--- a/pages/actions/[year].tsx
+++ b/pages/actions/[year].tsx
@@ -6,10 +6,11 @@ import { ActionsTable } from 'components/Actions/ActionsTable';
 import { StockLink } from 'components/Links';
 import { ParsedUrlQuery } from 'querystring';
 import { CellString, ActionProps } from 'components/Actions/actions.types';
+import { ActionsPaywall } from 'components/Actions/ActionsPaywall';
 
 export const ActionsAllYear = ({ year, data }: ActionProps) => {
 	if (Number(year) === new Date().getFullYear()) {
-		data = data.filter((d) => d.date.slice(-4) === year);
+		data.data = data.data.filter((d) => d.date.slice(-4) === year);
 	}
 
 	const columns = [
@@ -45,7 +46,20 @@ export const ActionsAllYear = ({ year, data }: ActionProps) => {
 				canonical={`actions/${year}/`}
 			/>
 			<ActionsLayout title={`${year} Corporate Actions`}>
-				<ActionsTable title="Actions" columndata={columns} rowdata={data} />
+				<ActionsTable
+					key={`Actions-${year}`}
+					title="Actions"
+					columndata={columns}
+					rowdata={data.data}
+					fullCount={data.fullCount}
+					type="all"
+					year={year}
+				/>
+				<ActionsPaywall
+					count={data.data.length}
+					fullCount={data.fullCount}
+					title="Actions"
+				/>
 			</ActionsLayout>
 		</>
 	);

--- a/pages/actions/acquisitions/[year].tsx
+++ b/pages/actions/acquisitions/[year].tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { StockLink } from 'components/Links';
 import { ParsedUrlQuery } from 'querystring';
 import { CellString, ActionProps } from 'components/Actions/actions.types';
+import { ActionsPaywall } from 'components/Actions/ActionsPaywall';
 
 export const ActionsAcquisitionsYear = ({ year, data }: ActionProps) => {
 	const columns = [
@@ -64,9 +65,18 @@ export const ActionsAcquisitionsYear = ({ year, data }: ActionProps) => {
 			/>
 			<ActionsLayout title={`${year} Mergers & Acquisitions`}>
 				<ActionsTable
+					key={`Acquisitions-${year}`}
 					title="Acquisitions"
 					columndata={columns}
-					rowdata={data}
+					rowdata={data.data}
+					fullCount={data.fullCount}
+					type="acquisitions"
+					year={year}
+				/>
+				<ActionsPaywall
+					count={data.data.length}
+					fullCount={data.fullCount}
+					title="Acquisitions"
 				/>
 			</ActionsLayout>
 		</>

--- a/pages/actions/acquisitions/index.tsx
+++ b/pages/actions/acquisitions/index.tsx
@@ -63,9 +63,12 @@ export const ActionsAcquisitions = ({ data }: ActionProps) => {
 			/>
 			<ActionsLayout title="Recent Mergers & Acquisitions">
 				<ActionsTable
+					key="Acquisitions"
 					title="Acquisitions"
 					columndata={columns}
-					rowdata={data}
+					rowdata={data.data}
+					fullCount={data.fullCount}
+					type="acquisitions"
 				/>
 			</ActionsLayout>
 		</>

--- a/pages/actions/bankruptcies/[year].tsx
+++ b/pages/actions/bankruptcies/[year].tsx
@@ -6,6 +6,7 @@ import { ActionsTable } from 'components/Actions/ActionsTable';
 import { StockLink } from 'components/Links';
 import { ParsedUrlQuery } from 'querystring';
 import { CellString, ActionProps } from 'components/Actions/actions.types';
+import { ActionsPaywall } from 'components/Actions/ActionsPaywall';
 
 export const ActionsBankruptciesYear = ({ year, data }: ActionProps) => {
 	const columns = [
@@ -38,9 +39,18 @@ export const ActionsBankruptciesYear = ({ year, data }: ActionProps) => {
 			/>
 			<ActionsLayout title={`${year} Bankruptcies`}>
 				<ActionsTable
+					key={`Bankruptcies-${year}`}
 					title="Bankruptcies"
 					columndata={columns}
-					rowdata={data}
+					rowdata={data.data}
+					fullCount={data.fullCount}
+					type="bankruptcies"
+					year={year}
+				/>
+				<ActionsPaywall
+					count={data.data.length}
+					fullCount={data.fullCount}
+					title="Bankruptcies"
 				/>
 			</ActionsLayout>
 		</>

--- a/pages/actions/bankruptcies/index.tsx
+++ b/pages/actions/bankruptcies/index.tsx
@@ -37,9 +37,12 @@ export const ActionsBankruptcies = ({ data }: ActionProps) => {
 			/>
 			<ActionsLayout title="Recent Bankruptcies">
 				<ActionsTable
+					key="Bankruptcies"
 					title="Bankruptcies"
 					columndata={columns}
-					rowdata={data}
+					rowdata={data.data}
+					fullCount={data.fullCount}
+					type="bankruptcies"
 				/>
 			</ActionsLayout>
 		</>

--- a/pages/actions/changes/[year].tsx
+++ b/pages/actions/changes/[year].tsx
@@ -6,6 +6,7 @@ import { ActionsTable } from 'components/Actions/ActionsTable';
 import { StockLink } from 'components/Links';
 import { ParsedUrlQuery } from 'querystring';
 import { CellString, ActionProps } from 'components/Actions/actions.types';
+import { ActionsPaywall } from 'components/Actions/ActionsPaywall';
 
 export const ActionsChangesYear = ({ year, data }: ActionProps) => {
 	const columns = [
@@ -47,7 +48,20 @@ export const ActionsChangesYear = ({ year, data }: ActionProps) => {
 				canonical={`actions/changes/${year}/`}
 			/>
 			<ActionsLayout title={`${year} Symbol Changes`}>
-				<ActionsTable title="Changes" columndata={columns} rowdata={data} />
+				<ActionsTable
+					key={`Changes-${year}`}
+					title="Changes"
+					columndata={columns}
+					rowdata={data.data}
+					fullCount={data.fullCount}
+					type="changes"
+					year={year}
+				/>
+				<ActionsPaywall
+					count={data.data.length}
+					fullCount={data.fullCount}
+					title="Symbol Changes"
+				/>
 			</ActionsLayout>
 		</>
 	);

--- a/pages/actions/changes/index.tsx
+++ b/pages/actions/changes/index.tsx
@@ -46,7 +46,14 @@ export const ActionsChanges = ({ data }: ActionProps) => {
 				canonical="actions/changes/"
 			/>
 			<ActionsLayout title="Recent Stock Symbol Changes">
-				<ActionsTable title="Changes" columndata={columns} rowdata={data} />
+				<ActionsTable
+					key="Changes"
+					title="Changes"
+					columndata={columns}
+					rowdata={data.data}
+					fullCount={data.fullCount}
+					type="changes"
+				/>
 			</ActionsLayout>
 		</>
 	);

--- a/pages/actions/delisted/[year].tsx
+++ b/pages/actions/delisted/[year].tsx
@@ -6,6 +6,7 @@ import { ActionsTable } from 'components/Actions/ActionsTable';
 import { StockLink } from 'components/Links';
 import { ParsedUrlQuery } from 'querystring';
 import { CellString, ActionProps } from 'components/Actions/actions.types';
+import { ActionsPaywall } from 'components/Actions/ActionsPaywall';
 
 export const ActionsDelistedYear = ({ year, data }: ActionProps) => {
 	const columns = [
@@ -38,9 +39,18 @@ export const ActionsDelistedYear = ({ year, data }: ActionProps) => {
 			/>
 			<ActionsLayout title={`${year} Delisted Stocks`}>
 				<ActionsTable
+					key={`Delistings-${year}`}
 					title="Delistings"
 					columndata={columns}
-					rowdata={data}
+					rowdata={data.data}
+					fullCount={data.fullCount}
+					type="delisted"
+					year={year}
+				/>
+				<ActionsPaywall
+					count={data.data.length}
+					fullCount={data.fullCount}
+					title="Delistings"
 				/>
 			</ActionsLayout>
 		</>

--- a/pages/actions/delisted/index.tsx
+++ b/pages/actions/delisted/index.tsx
@@ -37,9 +37,12 @@ export const ActionsDelisted = ({ data }: ActionProps) => {
 			/>
 			<ActionsLayout title="Recently Delisted Stocks">
 				<ActionsTable
+					key="Delistings"
 					title="Delistings"
 					columndata={columns}
-					rowdata={data}
+					rowdata={data.data}
+					fullCount={data.fullCount}
+					type="delisted"
 				/>
 			</ActionsLayout>
 		</>

--- a/pages/actions/index.tsx
+++ b/pages/actions/index.tsx
@@ -40,7 +40,14 @@ export const ActionsAll = ({ data }: ActionProps) => {
 				canonical="actions/"
 			/>
 			<ActionsLayout title="Recent Corporate Actions">
-				<ActionsTable title="Actions" columndata={columns} rowdata={data} />
+				<ActionsTable
+					key="Actions"
+					title="Actions"
+					columndata={columns}
+					rowdata={data.data}
+					fullCount={data.fullCount}
+					type="all"
+				/>
 			</ActionsLayout>
 		</>
 	);

--- a/pages/actions/listed/[year].tsx
+++ b/pages/actions/listed/[year].tsx
@@ -6,6 +6,7 @@ import { ActionsTable } from 'components/Actions/ActionsTable';
 import { StockLink } from 'components/Links';
 import { ParsedUrlQuery } from 'querystring';
 import { CellString, ActionProps } from 'components/Actions/actions.types';
+import { ActionsPaywall } from 'components/Actions/ActionsPaywall';
 
 export const ActionsListedYear = ({ year, data }: ActionProps) => {
 	const columns = [
@@ -38,9 +39,18 @@ export const ActionsListedYear = ({ year, data }: ActionProps) => {
 			/>
 			<ActionsLayout title={`${year} Listed Stocks`}>
 				<ActionsTable
+					key={`Listings-${year}`}
 					title="Listings"
 					columndata={columns}
-					rowdata={data}
+					rowdata={data.data}
+					fullCount={data.fullCount}
+					type="listed"
+					year={year}
+				/>
+				<ActionsPaywall
+					count={data.data.length}
+					fullCount={data.fullCount}
+					title="Listings"
 				/>
 			</ActionsLayout>
 		</>

--- a/pages/actions/listed/index.tsx
+++ b/pages/actions/listed/index.tsx
@@ -37,9 +37,12 @@ export const ActionsListed = ({ data }: ActionProps) => {
 			/>
 			<ActionsLayout title="Recently Listed Stocks">
 				<ActionsTable
+					key="listings"
 					title="Listings"
 					columndata={columns}
-					rowdata={data}
+					rowdata={data.data}
+					fullCount={data.fullCount}
+					type="listed"
 				/>
 			</ActionsLayout>
 		</>

--- a/pages/actions/spinoffs/[year].tsx
+++ b/pages/actions/spinoffs/[year].tsx
@@ -6,6 +6,7 @@ import { ActionsTable } from 'components/Actions/ActionsTable';
 import { StockLink } from 'components/Links';
 import { ParsedUrlQuery } from 'querystring';
 import { CellString, ActionProps } from 'components/Actions/actions.types';
+import { ActionsPaywall } from 'components/Actions/ActionsPaywall';
 
 export const ActionsSpinoffsYear = ({ year, data }: ActionProps) => {
 	const columns = [
@@ -58,9 +59,18 @@ export const ActionsSpinoffsYear = ({ year, data }: ActionProps) => {
 			/>
 			<ActionsLayout title={`${year} Stock Spinoffs`}>
 				<ActionsTable
+					key={`Spinoffs-${year}`}
 					title="Spinoffs"
 					columndata={columns}
-					rowdata={data}
+					rowdata={data.data}
+					fullCount={data.fullCount}
+					type="spinoffs"
+					year={year}
+				/>
+				<ActionsPaywall
+					count={data.data.length}
+					fullCount={data.fullCount}
+					title="Spinoffs"
 				/>
 			</ActionsLayout>
 		</>

--- a/pages/actions/spinoffs/index.tsx
+++ b/pages/actions/spinoffs/index.tsx
@@ -57,9 +57,12 @@ export const ActionsSpinoffs = ({ data }: ActionProps) => {
 			/>
 			<ActionsLayout title="Recent Stock Spinoffs">
 				<ActionsTable
+					key="Spinoffs"
 					title="Spinoffs"
 					columndata={columns}
-					rowdata={data}
+					rowdata={data.data}
+					fullCount={data.fullCount}
+					type="spinoffs"
 				/>
 			</ActionsLayout>
 		</>

--- a/pages/actions/splits/[year].tsx
+++ b/pages/actions/splits/[year].tsx
@@ -6,10 +6,9 @@ import { ActionsTable } from 'components/Actions/ActionsTable';
 import { StockLink } from 'components/Links';
 import { ParsedUrlQuery } from 'querystring';
 import { CellString, ActionProps } from 'components/Actions/actions.types';
+import { ActionsPaywall } from 'components/Actions/ActionsPaywall';
 
 export const ActionsSplitsYear = ({ year, data }: ActionProps) => {
-	const yearData = data.filter((d) => d.date.slice(-4) === year);
-
 	const columns = [
 		{
 			Header: 'Date',
@@ -48,9 +47,18 @@ export const ActionsSplitsYear = ({ year, data }: ActionProps) => {
 			/>
 			<ActionsLayout title={`${year} Stock Splits`}>
 				<ActionsTable
+					key={`Splits-${year}`}
 					title="Splits"
 					columndata={columns}
-					rowdata={yearData}
+					rowdata={data.data}
+					fullCount={data.fullCount}
+					type="splits"
+					year={year}
+				/>
+				<ActionsPaywall
+					count={data.data.length}
+					fullCount={data.fullCount}
+					title="Stock Splits"
 				/>
 			</ActionsLayout>
 		</>

--- a/pages/actions/splits/index.tsx
+++ b/pages/actions/splits/index.tsx
@@ -44,7 +44,14 @@ export const ActionsSplits = ({ data }: ActionProps) => {
 				canonical="actions/splits/"
 			/>
 			<ActionsLayout title="Recent Stock Splits">
-				<ActionsTable title="Splits" columndata={columns} rowdata={data} />
+				<ActionsTable
+					key="Splits"
+					title="Splits"
+					columndata={columns}
+					rowdata={data.data}
+					fullCount={data.fullCount}
+					type="splits"
+				/>
 			</ActionsLayout>
 		</>
 	);


### PR DESCRIPTION
> Massively reduces HTML size of corporate actions pages.
>> Makes page load much faster for a user on a poor connection (HTML often < 14kB)
>> Reduces bandwidth usage significantly, especially from crawlers.

> Prevent corporate actions tables from rendering twice by moving some components out of the ActionsTable component.

> Show a gray "unavailable" box if financials are empty, slightly better UX