### PR TITLE
Limit holdings data fetching for non-Pro users

### DIFF
--- a/components/Actions/ActionsTable.tsx
+++ b/components/Actions/ActionsTable.tsx
@@ -8,7 +8,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { Controls } from 'components/Controls/_Controls';
 import styles from './ActionsTable.module.css';
 import { authState } from 'state/authState';
-import { getActionsData } from 'functions/callBackEnd';
+import { getActionsDataFull } from 'functions/callBackEnd';
 
 interface Props {
 	title: string;
@@ -35,11 +35,7 @@ export const ActionsTable = ({
 	// If pro user and data is limited, fetch the full data
 	useEffect(() => {
 		async function fetchFullActions() {
-			const res = await getActionsData(
-				type,
-				year,
-				process.env.NEXT_PUBLIC_PROKEY
-			);
+			const res = await getActionsDataFull(type, year);
 
 			if (res.data && res.data.length > count) {
 				setDataRows(res.data);

--- a/components/Holdings/HoldingsPaywall.tsx
+++ b/components/Holdings/HoldingsPaywall.tsx
@@ -1,7 +1,10 @@
+import { authState } from 'state/authState';
 import { Button } from 'components/Button';
 
 export const HoldingsPaywall = ({ total }: { total: number }) => {
-	if (total < 200) {
+	const isPro = authState((state) => state.isPro);
+
+	if (isPro || total < 200) {
 		return null;
 	}
 

--- a/components/News/NewsArticle.tsx
+++ b/components/News/NewsArticle.tsx
@@ -20,7 +20,6 @@ export const NewsArticle = ({ index, item, related }: Props) => {
 					rel="nofollow noopener noreferrer"
 					aria-hidden="true"
 					tabIndex={-1}
-					className="sm:mt-1"
 				>
 					<img
 						loading="lazy"
@@ -28,11 +27,10 @@ export const NewsArticle = ({ index, item, related }: Props) => {
 						width={640}
 						height={360}
 						alt=""
-						className="rounded"
 					/>
 				</a>
-				<div className="flex flex-col">
-					<h3 className="hh3 mb-2 mt-3 sm:mt-0 leading-snug sm:leading-tight sm:order-2 hover:text-blue-brand_sharp">
+				<div>
+					<h3>
 						<a
 							href={item.url}
 							target="_blank"
@@ -41,16 +39,14 @@ export const NewsArticle = ({ index, item, related }: Props) => {
 							{item.title}
 						</a>
 					</h3>
-					<p className="text-gray-800 sm:order-3 text-[0.95rem]">
-						{item.text}
-					</p>
-					{item.tickers && (
-						<div className="mt-1.5 sm:mt-1 sm:order-4">
+					<p>{item.text}</p>
+					{item.tickers && item.tickers.length > 0 && (
+						<div className="news-t">
 							<Tickers tickers={item.tickers} intro={related} />
 						</div>
 					)}
 
-					<div className="mt-1 text-sm text-gray-700 sm:order-1 sm:mt-0">
+					<div>
 						<span title={item.timeFull}>{item.timeAgo}</span>
 						<span> - {item.source}</span>
 					</div>

--- a/components/News/NewsVideo.tsx
+++ b/components/News/NewsVideo.tsx
@@ -14,21 +14,17 @@ export const NewsVideo = ({ index, item, related }: Props) => {
 		<>
 			{(index === 3 || index === 10) && <NewsAds index={index} />}
 			<div className="news-video">
-				<h3 className="hh3 leading-snug sm:leading-tight sm:order-2">
-					{item.title}
-				</h3>
-				<div className="mb-3 sm:order-3 lg:pr-2">
+				<h3>{item.title}</h3>
+				<div className="news-e">
 					<LiteYouTubeEmbed id={item.url} title={item.title} />
 				</div>
-				<p className="text-gray-800 sm:order-4 text-[0.95rem]">
-					{item.text}
-				</p>
-				{item.tickers && (
-					<div className="mt-1.5 sm:mt-1 sm:order-5">
+				<p>{item.text}</p>
+				{item.tickers && item.tickers.length > 0 && (
+					<div className="news-t">
 						<Tickers tickers={item.tickers} intro={related} />
 					</div>
 				)}
-				<div className="mt-1 text-sm text-gray-700 sm:order-1 sm:mt-0">
+				<div>
 					<span title={item.timeFull}>{item.timeAgo}</span>
 					<span> - {item.source}</span>
 				</div>

--- a/components/Overview/TopTables.tsx
+++ b/components/Overview/TopTables.tsx
@@ -1,52 +1,45 @@
 import { Overview } from 'types/Overview';
 import { Quote } from 'types/Quote';
 
-const cssRows =
-	'flex flex-col sm:table-row border-b border-gray-200 py-1 sm:py-0';
-const cssCells = 'py-[1px] sm:py-2 px-1 whitespace-nowrap';
-const cssCellLeft = cssCells;
-const cssCellRight =
-	cssCells + ' text-left sm:text-right text-base sm:text-small font-semibold';
-
 export const InfoTable = ({ data }: { data: Overview }) => {
 	return (
-		<table className="text-small w-[48%] lg:w-auto lg:min-w-[210px] text-gray-900">
+		<table className="top-table">
 			<tbody>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>Market Cap</td>
-					<td className={cssCellRight}>{data.marketCap}</td>
+				<tr>
+					<td>Market Cap</td>
+					<td>{data.marketCap}</td>
 				</tr>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>Revenue (ttm)</td>
-					<td className={cssCellRight}>{data.revenue}</td>
+				<tr>
+					<td>Revenue (ttm)</td>
+					<td>{data.revenue}</td>
 				</tr>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>Net Income (ttm)</td>
-					<td className={cssCellRight}>{data.netIncome}</td>
+				<tr>
+					<td>Net Income (ttm)</td>
+					<td>{data.netIncome}</td>
 				</tr>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>Shares Out</td>
-					<td className={cssCellRight}>{data.sharesOut}</td>
+				<tr>
+					<td>Shares Out</td>
+					<td>{data.sharesOut}</td>
 				</tr>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>EPS (ttm)</td>
-					<td className={cssCellRight}>{data.eps}</td>
+				<tr>
+					<td>EPS (ttm)</td>
+					<td>{data.eps}</td>
 				</tr>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>PE Ratio</td>
-					<td className={cssCellRight}>{data.peRatio}</td>
+				<tr>
+					<td>PE Ratio</td>
+					<td>{data.peRatio}</td>
 				</tr>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>Forward PE</td>
-					<td className={cssCellRight}>{data.forwardPE}</td>
+				<tr>
+					<td>Forward PE</td>
+					<td>{data.forwardPE}</td>
 				</tr>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>Dividend</td>
-					<td className={cssCellRight}>{data.dividend}</td>
+				<tr>
+					<td>Dividend</td>
+					<td>{data.dividend}</td>
 				</tr>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>Ex-Dividend Date</td>
-					<td className={cssCellRight}>{data.exDividendDate}</td>
+				<tr>
+					<td>Ex-Dividend Date</td>
+					<td>{data.exDividendDate}</td>
 				</tr>
 			</tbody>
 		</table>
@@ -64,43 +57,43 @@ export const QuoteTable = ({
 	const previous = !quote || !quote.brandNew ? 'Previous Close' : 'IPO Price';
 
 	return (
-		<table className="text-small w-[48%] lg:w-auto lg:min-w-[210px] text-gray-900">
+		<table className="top-table">
 			<tbody>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>Volume</td>
-					<td className={cssCellRight}>{volume}</td>
+				<tr>
+					<td>Volume</td>
+					<td>{volume}</td>
 				</tr>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>Open</td>
-					<td className={cssCellRight}>{data.open}</td>
+				<tr>
+					<td>Open</td>
+					<td>{data.open}</td>
 				</tr>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>{previous}</td>
-					<td className={cssCellRight}>{data.close}</td>
+				<tr>
+					<td>{previous}</td>
+					<td>{data.close}</td>
 				</tr>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>Day&apos;s Range</td>
-					<td className={cssCellRight}>{data.rangeDay}</td>
+				<tr>
+					<td>Day&apos;s Range</td>
+					<td>{data.rangeDay}</td>
 				</tr>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>52-Week Range</td>
-					<td className={cssCellRight}>{data.range52w}</td>
+				<tr>
+					<td>52-Week Range</td>
+					<td>{data.range52w}</td>
 				</tr>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>Beta</td>
-					<td className={cssCellRight}>{data.beta}</td>
+				<tr>
+					<td>Beta</td>
+					<td>{data.beta}</td>
 				</tr>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>Analysts</td>
-					<td className={cssCellRight}>{data.analysts}</td>
+				<tr>
+					<td>Analysts</td>
+					<td>{data.analysts}</td>
 				</tr>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>Price Target</td>
-					<td className={cssCellRight}>{data.target}</td>
+				<tr>
+					<td>Price Target</td>
+					<td>{data.target}</td>
 				</tr>
-				<tr className={cssRows}>
-					<td className={cssCellLeft}>Est. Earnings Date</td>
-					<td className={cssCellRight}>{data.earningsDate}</td>
+				<tr>
+					<td>Est. Earnings Date</td>
+					<td>{data.earningsDate}</td>
 				</tr>
 			</tbody>
 		</table>

--- a/components/PriceChart/PriceChartControls.tsx
+++ b/components/PriceChart/PriceChartControls.tsx
@@ -6,48 +6,38 @@ interface Props {
 }
 
 export const Controls = ({ chartTime, setChartTime }: Props) => {
-	const common =
-		' text-smaller py-1 px-0.5 xs:px-[3px] bp:px-1.5 sm:px-2 rounded-md';
-	const active = 'bp:bg-gray-100 text-gray-800 font-semibold' + common;
-	const inactive =
-		'text-gray-900 hover:text-gray-900 hover:text-shadow' + common;
-
 	return (
-		<ul className="flex space-x-[3px] xs:space-x-1 whitespace-nowrap overflow-x-auto hide-scroll">
+		<ul className="price-chart">
 			<li>
 				<button
-					className={chartTime === '1D' ? active : inactive}
+					className={chartTime === '1D' ? 'active' : 'inactive'}
 					onClick={() => setChartTime('1D')}
 				>
-					<span className="block sm:hidden lg:block xl:hidden">1D</span>
-					<span className="hidden sm:block lg:hidden xl:block">1 Day</span>
+					<span>1D</span>
+					<span>1 Day</span>
 				</button>
 			</li>
 			<li>
 				<button
-					className={chartTime === '5D' ? active : inactive}
+					className={chartTime === '5D' ? 'active' : 'inactive'}
 					onClick={() => setChartTime('5D')}
 				>
-					<span className="block sm:hidden lg:block xl:hidden">5D</span>
-					<span className="hidden sm:block lg:hidden xl:block">
-						5 Days
-					</span>
+					<span>5D</span>
+					<span>5 Days</span>
 				</button>
 			</li>
 			<li>
 				<button
-					className={chartTime === '1M' ? active : inactive}
+					className={chartTime === '1M' ? 'active' : 'inactive'}
 					onClick={() => setChartTime('1M')}
 				>
-					<span className="block sm:hidden lg:block xl:hidden">1M</span>
-					<span className="hidden sm:block lg:hidden xl:block">
-						1 Month
-					</span>
+					<span>1M</span>
+					<span>1 Month</span>
 				</button>
 			</li>
 			<li>
 				<button
-					className={chartTime === 'YTD' ? active : inactive}
+					className={chartTime === 'YTD' ? 'active' : 'inactive'}
 					onClick={() => setChartTime('YTD')}
 				>
 					YTD
@@ -55,29 +45,25 @@ export const Controls = ({ chartTime, setChartTime }: Props) => {
 			</li>
 			<li>
 				<button
-					className={chartTime === '1Y' ? active : inactive}
+					className={chartTime === '1Y' ? 'active' : 'inactive'}
 					onClick={() => setChartTime('1Y')}
 				>
-					<span className="block sm:hidden lg:block xl:hidden">1Y</span>
-					<span className="hidden sm:block lg:hidden xl:block">
-						1 Year
-					</span>
+					<span>1Y</span>
+					<span>1 Year</span>
 				</button>
 			</li>
 			<li>
 				<button
-					className={chartTime === '5Y' ? active : inactive}
+					className={chartTime === '5Y' ? 'active' : 'inactive'}
 					onClick={() => setChartTime('5Y')}
 				>
-					<span className="block sm:hidden lg:block xl:hidden">5Y</span>
-					<span className="hidden sm:block lg:hidden xl:block">
-						5 Years
-					</span>
+					<span>5Y</span>
+					<span>5 Years</span>
 				</button>
 			</li>
 			<li>
 				<button
-					className={chartTime === 'MAX' ? active : inactive}
+					className={chartTime === 'MAX' ? 'active' : 'inactive'}
 					onClick={() => setChartTime('MAX')}
 				>
 					Max

--- a/components/PriceChart/_PriceChart.tsx
+++ b/components/PriceChart/_PriceChart.tsx
@@ -79,7 +79,7 @@ export const PriceChart = ({ info }: { info: Info }) => {
 					/>
 				)}
 			</div>
-			<div className="h-[240px] sm:h-[300px]">
+			<div className="h-[240px] sm:h-[300px] overflow-x-auto hide-scroll">
 				{chartData && chartData.length > 0 && (
 					<Chart chartData={chartData} chartTime={chartTime} />
 				)}

--- a/functions/callBackEnd.ts
+++ b/functions/callBackEnd.ts
@@ -1,5 +1,7 @@
 import { getData } from 'functions/API';
 
+const PRO_KEY = process.env.NEXT_PUBLIC_PROKEY ?? null;
+
 interface Response {
 	status: number;
 	data: any;
@@ -19,6 +21,16 @@ export function respond(response: Response, revalidate: number) {
 export async function getPageData(page: string, symbol: string, reval: number) {
 	const response = await getData(`${page}?symbol=${symbol}`);
 	return respond(response, reval);
+}
+
+export async function getPageDataFull(page: string, symbol: string) {
+	const url = `${page}?symbol=${symbol}&f=${PRO_KEY}`;
+	const response = await getData(url);
+
+	if (response.status === 200) {
+		return response.data;
+	}
+	return [];
 }
 
 export async function getStockFinancials(
@@ -50,19 +62,13 @@ export async function getIpoData(query: string) {
 	return response;
 }
 
-export async function getActionsData(
-	query: string,
-	year?: string,
-	key?: string
-) {
-	const url =
-		year && key
-			? `actions?q=${query}&y=${year}&f=${key}`
-			: year
-			? `actions?q=${query}&y=${year}`
-			: `actions?q=${query}`;
-
+export async function getActionsData(query: string, year?: string) {
+	const url = year ? `actions?q=${query}&y=${year}` : `actions?q=${query}`;
 	const response = await getData(url);
+	return response;
+}
 
+export async function getActionsDataFull(query: string, year?: string) {
+	const response = await getData(`actions?q=${query}&y=${year}&f=${PRO_KEY}`);
 	return response;
 }

--- a/pages/etf/[symbol]/holdings.tsx
+++ b/pages/etf/[symbol]/holdings.tsx
@@ -8,6 +8,7 @@ import { SEO } from 'components/SEO';
 import { getPageData } from 'functions/callBackEnd';
 import { HoldingsTable } from 'components/Holdings/_HoldingsTable';
 import { NewsWidget } from 'components/News/NewsWidget';
+import { HoldingsPaywall } from 'components/Holdings/HoldingsPaywall';
 
 interface Props {
 	info: Info;
@@ -47,7 +48,15 @@ const Holdings = ({ info, data, news }: Props) => {
 							)}
 						</div>
 						{data.count ? (
-							<HoldingsTable rawdata={data.list} />
+							<>
+								<HoldingsTable
+									key={info.symbol}
+									symbol={info.symbol}
+									rawdata={data.list}
+									fullCount={data.count}
+								/>
+								<HoldingsPaywall total={data.count} />
+							</>
 						) : (
 							<div className="text-lg">
 								No holdings were found for the {info.ticker} ETF

--- a/pages/pro/index.tsx
+++ b/pages/pro/index.tsx
@@ -42,7 +42,7 @@ export default function LandingPage() {
 			<main>
 				<header className="bg-gray-100 py-12 md:py-32 border-b border-gray-200 shadow-sm px-4 landscape:border-t-2 landscape:md:border-t-0">
 					<div className="max-w-[850px] mx-auto text-center px-6 sm:px-0">
-						<h1 className="text-3xl xs:text-4xl sm:text-[60px] font-bold mb-5 text-gray-800">
+						<h1 className="text-3xl xs:text-4xl sm:text-[60px] font-bold mb-8 text-gray-800">
 							Stock Analysis Pro
 						</h1>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -246,6 +246,35 @@
 		@apply bg-white p-4 sm:px-0 sm:py-6 first:pt-5 last:pb-1 shadow sm:shadow-none sm:grid sm:grid-cols-news gap-4 lg:gap-5;
 	}
 
+	.news-article > a {
+		@apply sm:mt-1;
+	}
+
+	.news-article > a > img {
+		@apply rounded;
+	}
+
+	.news-article > div {
+		@apply flex flex-col;
+	}
+
+	.news-article > div > h3 {
+		@apply text-xl font-bold mb-2 mt-3 sm:mt-0 leading-snug sm:leading-tight sm:order-2 hover:text-blue-brand_sharp;
+	}
+
+	.news-article > div > p {
+		@apply text-gray-800 sm:order-3 text-[0.95rem];
+	}
+
+	.news-article > div > div.news-t {
+		@apply mt-1.5 sm:mt-1 sm:order-4;
+	}
+
+	.news-article > div > div:last-child,
+	.news-video > div:last-child {
+		@apply mt-1 text-sm text-gray-700 sm:order-1 sm:mt-0;
+	}
+
 	.news-spns {
 		@apply bg-white p-4 sm:px-0 sm:py-6 first:pt-5 last:pb-1 shadow sm:shadow-none;
 	}
@@ -254,8 +283,64 @@
 		@apply flex flex-col bg-white p-4 sm:px-0 sm:py-6 first:pt-3 last:pb-1 sm:first:pt-4 shadow sm:shadow-none;
 	}
 
+	.news-video > h3 {
+		@apply text-xl font-bold mb-2.5 xs:mb-3 leading-snug sm:leading-tight sm:order-2;
+	}
+
+	.news-video > div.news-e {
+		@apply mb-3 sm:order-3 lg:pr-2;
+	}
+
+	.news-video > p {
+		@apply text-gray-800 sm:order-4 text-[0.95rem];
+	}
+
+	.news-video > div.news-t {
+		@apply mt-1.5 sm:mt-1 sm:order-5;
+	}
+
 	.news-ticker {
 		@apply inline-flex items-center px-1.5 py-0.5 ml-1 sm:ml-1.5 mb-1 rounded-md text-sm font-medium bg-gray-100 hover:bg-gray-200 bll;
+	}
+
+	.price-chart {
+		@apply flex space-x-[3px] xs:space-x-1 whitespace-nowrap overflow-x-auto hide-scroll;
+	}
+
+	.price-chart > li > button {
+		@apply text-smaller py-1 px-0.5 xs:px-[3px] bp:px-1.5 sm:px-2 rounded-md;
+	}
+
+	.price-chart > li > button.inactive {
+		@apply text-gray-900 hover:text-gray-900 hover:text-shadow;
+	}
+
+	.price-chart > li > button.active {
+		@apply bp:bg-gray-100 text-gray-800 font-semibold;
+	}
+
+	.price-chart > li > button > span:first-child {
+		@apply block sm:hidden lg:block xl:hidden;
+	}
+
+	.price-chart > li > button > span:last-child {
+		@apply hidden sm:block lg:hidden xl:block;
+	}
+
+	.top-table {
+		@apply text-small w-[48%] lg:w-auto lg:min-w-[210px] text-gray-900;
+	}
+
+	.top-table tr {
+		@apply flex flex-col sm:table-row border-b border-gray-200 py-1 sm:py-0;
+	}
+
+	.top-table tr td {
+		@apply py-[1px] sm:py-2 px-1 whitespace-nowrap;
+	}
+
+	.top-table tr td:last-child {
+		@apply text-left sm:text-right text-base sm:text-small font-semibold;
 	}
 
 	.green-quote {


### PR DESCRIPTION
> Limit holdings data fetched for non-Pro users to 200
>> If pro user, load the rest of the data client-side
>> Significantly reduces initial HTML size and bandwidth use from crawlers

> Moved some tailwind classes into globals.css to reduce HTML size