### PR TITLE
Adjust IPO calendar tables

### DIFF
--- a/components/Ads/Dianomi/NewsAd1.tsx
+++ b/components/Ads/Dianomi/NewsAd1.tsx
@@ -1,6 +1,6 @@
 import Script from 'next/script';
 
-export const NewsAd1 = () => {
+export function NewsAd1() {
 	return (
 		<>
 			<div className="news-spns">
@@ -16,4 +16,4 @@ export const NewsAd1 = () => {
 			</div>
 		</>
 	);
-};
+}

--- a/components/IPOs/CalendarTable.tsx
+++ b/components/IPOs/CalendarTable.tsx
@@ -63,7 +63,7 @@ const NoIpos = ({ title }: { title: string }) => {
 			);
 		}
 
-		case 'Next Week or Later': {
+		case 'Next Week': {
 			return (
 				<div>
 					<h2 className="hh2">{title} (0)</h2>

--- a/components/IPOs/CalendarTable.tsx
+++ b/components/IPOs/CalendarTable.tsx
@@ -57,7 +57,7 @@ const NoIpos = ({ title }: { title: string }) => {
 				<div>
 					<h2 className="hh2 mb-2">{title} (0)</h2>
 					<p className="text-lg text-gray-900">
-						There are no upcoming IPOs remaining for the current week.
+						There are no upcoming IPOs remaining for this week.
 					</p>
 				</div>
 			);
@@ -96,7 +96,7 @@ export const CalendarTable = ({ title, data, tableId }: Props) => {
 	} = tableInstance;
 
 	const thisWeek = title === 'IPOs This Week' ? true : false;
-	const nextWeek = title === 'Next Week or Later' ? true : false;
+	const nextWeek = title === 'Next Week' ? true : false;
 
 	const count = data.length;
 
@@ -165,8 +165,8 @@ export const CalendarTable = ({ title, data, tableId }: Props) => {
 				</table>
 			</div>
 			{(thisWeek || nextWeek) && (
-				<span className="text-sm text-gray-600 mt-1">
-					* Upcoming IPO dates are estimated and may change
+				<span className="text-sm text-gray-600 mt-1 ml-1">
+					Upcoming IPO dates are estimated and may change.
 				</span>
 			)}
 		</div>

--- a/components/News/NewsAds.tsx
+++ b/components/News/NewsAds.tsx
@@ -2,12 +2,12 @@ import { authState } from 'state/authState';
 import { NewsAd1 } from 'components/Ads/Dianomi/NewsAd1';
 // import { NewsAd2 } from 'components/Ads/Dianomi/NewsAd2';
 
-export const NewsAds = ({ index }: { index: number }) => {
+export function NewsAds({ index, count }: { index: number; count: number }) {
 	const status = authState((state) => state.status);
 	const isPro = authState((state) => state.isPro);
 
 	if (status === 'completed' && !isPro) {
-		if (index === 3) {
+		if (index === 2 || (count < 3 && count === index + 1)) {
 			return <NewsAd1 />;
 		}
 		// if (index === 10) {
@@ -16,4 +16,4 @@ export const NewsAds = ({ index }: { index: number }) => {
 	}
 
 	return null;
-};
+}

--- a/components/News/NewsArticle.tsx
+++ b/components/News/NewsArticle.tsx
@@ -7,12 +7,12 @@ interface Props {
 	index: number;
 	item: News;
 	related?: string;
+	count: number;
 }
 
-export const NewsArticle = ({ index, item, related }: Props) => {
+export const NewsArticle = ({ index, item, related, count }: Props) => {
 	return (
 		<>
-			{(index === 3 || index === 10) && <NewsAds index={index} />}
 			<div className="news-article">
 				<a
 					href={item.url}
@@ -52,6 +52,9 @@ export const NewsArticle = ({ index, item, related }: Props) => {
 					</div>
 				</div>
 			</div>
+			{(index === 2 || (count < 3 && count === index + 1)) && (
+				<NewsAds index={index} count={count} />
+			)}
 		</>
 	);
 };

--- a/components/News/NewsVideo.tsx
+++ b/components/News/NewsVideo.tsx
@@ -7,12 +7,12 @@ interface Props {
 	index: number;
 	item: News;
 	related?: string;
+	count: number;
 }
 
-export const NewsVideo = ({ index, item, related }: Props) => {
+export const NewsVideo = ({ index, item, related, count }: Props) => {
 	return (
 		<>
-			{(index === 3 || index === 10) && <NewsAds index={index} />}
 			<div className="news-video">
 				<h3>{item.title}</h3>
 				<div className="news-e">
@@ -29,6 +29,9 @@ export const NewsVideo = ({ index, item, related }: Props) => {
 					<span> - {item.source}</span>
 				</div>
 			</div>
+			{(index === 2 || (count < 3 && count === index + 1)) && (
+				<NewsAds index={index} count={count} />
+			)}
 		</>
 	);
 };

--- a/components/News/_NewsFeed.tsx
+++ b/components/News/_NewsFeed.tsx
@@ -8,6 +8,8 @@ interface Props {
 }
 
 export const NewsFeed = ({ data, related }: Props) => {
+	const count = data.length;
+
 	return (
 		<div className="bg-gray-200 sm:bg-white flex flex-col space-y-3 sm:space-y-0 sm:divide-y mb-2 sm:divide-gray-100 sm:border-b sm:border-gray-100 lg:border-0">
 			{data.map((item, index) => {
@@ -18,6 +20,7 @@ export const NewsFeed = ({ data, related }: Props) => {
 							index={index}
 							item={item}
 							related={related}
+							count={count}
 						/>
 					);
 				} else {
@@ -27,6 +30,7 @@ export const NewsFeed = ({ data, related }: Props) => {
 							index={index}
 							item={item}
 							related={related}
+							count={count}
 						/>
 					);
 				}

--- a/components/Overview/ProfileWidget.tsx
+++ b/components/Overview/ProfileWidget.tsx
@@ -15,7 +15,7 @@ interface Props {
 export const Profile = ({ info, data }: Props) => {
 	return (
 		<div className="text-gray-900">
-			<h2 className="hh2 mb-2">About {info.ticker}</h2>
+			<h2 className="hh2 mb-2">{`About ${info.ticker}`}</h2>
 			<p>
 				{data.description}{' '}
 				{info.type === 'stocks' && (

--- a/pages/ipos/calendar.tsx
+++ b/pages/ipos/calendar.tsx
@@ -15,6 +15,7 @@ interface Props {
 	data: {
 		thisweek: IpoUpcoming[];
 		nextweek: IpoUpcoming[];
+		later: IpoUpcoming[];
 		highprofile: IpoUpcoming[];
 		unknown: IpoUpcoming[];
 	};
@@ -43,9 +44,14 @@ export const IpoCalendar = ({ data, news, recent }: Props) => {
 								tableId="this-week"
 							/>
 							<CalendarTable
-								title="Next Week or Later"
+								title="Next Week"
 								data={data.nextweek}
 								tableId="next-week"
+							/>
+							<CalendarTable
+								title="Scheduled for Later"
+								data={data.later}
+								tableId="later"
 							/>
 							<CalendarTable
 								title="Upcoming High-Profile IPOs"


### PR DESCRIPTION
- On the IPO calendar, instead of showing "Next Week or Later" -- split it into two tables -- "Next Week" and "Scheduled for Later"
- Make news feed ad also show if only 1-3 news items