### PR TITLE
IPO calendar improvements, use new chart endpoint

### DIFF
--- a/components/Alerts/Information.tsx
+++ b/components/Alerts/Information.tsx
@@ -2,20 +2,26 @@ import { InformationCircleIcon } from '@heroicons/react/solid';
 
 interface Props {
 	message: string;
+	classes?: string;
 }
 
-export const Information = ({ message }: Props) => (
-	<div className="bg-blue-50 border-l-4 border-blue-400 p-4 text-blue-700">
-		<div className="flex flex-row items-center">
-			<div className="flex-shrink-0">
-				<InformationCircleIcon
-					className="h-5 w-5 text-blue-400"
-					aria-hidden="true"
-				/>
-			</div>
-			<div className="ml-3 sm:ml-4">
-				<span className="text-base">{message}</span>
+export const Information = ({ message, classes }: Props) => {
+	let css = 'bg-blue-50 border-l-4 border-blue-400 p-4 text-blue-700';
+	if (classes) css += ` ${classes}`;
+
+	return (
+		<div className={css}>
+			<div className="flex flex-row items-center">
+				<div className="flex-shrink-0">
+					<InformationCircleIcon
+						className="h-5 w-5 text-blue-400"
+						aria-hidden="true"
+					/>
+				</div>
+				<div className="ml-3 sm:ml-4">
+					<span>{message}</span>
+				</div>
 			</div>
 		</div>
-	</div>
-);
+	);
+};

--- a/components/IPOs/CalendarStatsMobile.tsx
+++ b/components/IPOs/CalendarStatsMobile.tsx
@@ -14,7 +14,7 @@ export function CalendarStatsMobile({ data }: { data: CalendarData }) {
 			<h2 className="text-[1.4rem] font-bold mb-1.5 text-gray-800">
 				Calendar Statistics
 			</h2>
-			<div className="border-t border-b pt-1 pb-2 text-xs sm:text-sm font-medium text-gray-600 px-1.5">
+			<div className="border-t border-b pt-2 pb-3 text-xs sm:text-sm font-medium text-gray-600 px-1.5">
 				<div className="flex flex-row justify-between text-center">
 					<div className="flex flex-col">
 						<div className="order-2">This Week</div>

--- a/components/IPOs/CalendarStatsMobile.tsx
+++ b/components/IPOs/CalendarStatsMobile.tsx
@@ -1,6 +1,6 @@
 import { CalendarData } from 'types/Ipos';
 
-export function CalendarStats({ data }: { data: CalendarData }) {
+export function CalendarStatsMobile({ data }: { data: CalendarData }) {
 	const total =
 		data.thisweek.length +
 		data.nextweek.length +
@@ -10,51 +10,41 @@ export function CalendarStats({ data }: { data: CalendarData }) {
 	const hasLater = data.later && data.later?.length > 0;
 
 	return (
-		<div>
-			<h2 className="hh2 text-[1.4rem] text-gray-800">
+		<div className="pt-2 pb-3 lg:hidden">
+			<h2 className="text-[1.4rem] font-bold mb-1.5 text-gray-800">
 				Calendar Statistics
 			</h2>
-			<div
-				className={`border py-4 rounded text-sm font-medium text-gray-600${
-					hasLater ? ' px-6' : ' px-2'
-				}`}
-			>
-				<div
-					className={`${
-						hasLater
-							? 'flex flex-wrap justify-around lg:justify-between gap-x-6 gap-y-4 text-center'
-							: 'grid grid-cols-2 text-center gap-y-4'
-					}`}
-				>
+			<div className="border-t border-b pt-1 pb-2 text-xs sm:text-sm font-medium text-gray-600 px-1.5">
+				<div className="flex flex-row justify-between text-center">
 					<div className="flex flex-col">
 						<div className="order-2">This Week</div>
-						<div className="order-1 font-semibold text-4xl text-gray-800">
+						<div className="order-1 font-semibold text-3xl sm:text-4xl text-gray-800">
 							{data.thisweek.length}
 						</div>
 					</div>
 					<div className="flex flex-col">
 						<div className="order-2">Next Week</div>
-						<div className="order-1 font-semibold text-4xl text-gray-800">
+						<div className="order-1 font-semibold text-3xl sm:text-4xl text-gray-800">
 							{data.nextweek.length}
 						</div>
 					</div>
 					{hasLater && (
 						<div className="flex flex-col">
 							<div className="order-2">Later</div>
-							<div className="order-1 font-semibold text-4xl text-gray-800">
+							<div className="order-1 font-semibold text-3xl sm:text-4xl text-gray-800">
 								{data.later.length}
 							</div>
 						</div>
 					)}
 					<div className="flex flex-col">
 						<div className="order-2">Unscheduled</div>
-						<div className="order-1 font-semibold text-4xl text-gray-800">
+						<div className="order-1 font-semibold text-3xl sm:text-4xl text-gray-800">
 							{data.unknown.length}
 						</div>
 					</div>
 					<div className="flex flex-col">
 						<div className="order-2">Total</div>
-						<div className="order-1 font-semibold text-4xl text-gray-800">
+						<div className="order-1 font-semibold text-3xl sm:text-4xl text-gray-800">
 							{total}
 						</div>
 					</div>

--- a/components/IPOs/CalendarTable.tsx
+++ b/components/IPOs/CalendarTable.tsx
@@ -81,7 +81,7 @@ const columns: Column[] = [
 
 const NoIpos = ({ title }: { title: string }) => {
 	switch (title) {
-		case 'IPOs This Week': {
+		case 'This Week': {
 			return (
 				<div>
 					<h2 className="hh2 mb-2">{title} (0)</h2>
@@ -128,9 +128,6 @@ export const CalendarTable = ({ title, data, tableId }: Props) => {
 		state: { globalFilter },
 	} = tableInstance;
 
-	const thisWeek = title === 'IPOs This Week' ? true : false;
-	const nextWeek = title === 'Next Week' ? true : false;
-
 	const count = data.length;
 
 	if (count === 0) {
@@ -161,7 +158,7 @@ export const CalendarTable = ({ title, data, tableId }: Props) => {
 						tableId={tableId}
 					/>
 				</div>
-				{title === 'More Upcoming IPOs' && (
+				{title === 'Unscheduled' && (
 					<div className="hidden md:block">
 						<Filter
 							useAsyncDebounce={useAsyncDebounce}
@@ -216,11 +213,6 @@ export const CalendarTable = ({ title, data, tableId }: Props) => {
 					</tbody>
 				</table>
 			</div>
-			{(thisWeek || nextWeek) && (
-				<span className="text-sm text-gray-600 mt-1 ml-1">
-					Upcoming IPO dates are estimated and may change.
-				</span>
-			)}
 		</div>
 	);
 };

--- a/components/IPOs/CalendarTable.tsx
+++ b/components/IPOs/CalendarTable.tsx
@@ -168,7 +168,6 @@ export const CalendarTable = ({ title, data, tableId }: Props) => {
 					</div>
 				)}
 			</div>
-
 			<div className="overflow-x-auto">
 				<table className="ipotable" id={tableId}>
 					<thead>

--- a/components/IPOs/IPONavigation.tsx
+++ b/components/IPOs/IPONavigation.tsx
@@ -37,6 +37,18 @@ export const IPONavigation = () => {
 							</Link>
 						</li>
 						<li>
+							<Link href="/ipos/statistics/" prefetch={false}>
+								<a
+									data-title="Statistics"
+									className={
+										path.two === 'statistics' ? 'active' : 'inactive'
+									}
+								>
+									Statistics
+								</a>
+							</Link>
+						</li>
+						<li>
 							<Link href="/ipos/screener/" prefetch={false}>
 								<a
 									data-title="Screener"
@@ -57,18 +69,6 @@ export const IPONavigation = () => {
 									}
 								>
 									News
-								</a>
-							</Link>
-						</li>
-						<li>
-							<Link href="/ipos/statistics/" prefetch={false}>
-								<a
-									data-title="Statistics"
-									className={
-										path.two === 'statistics' ? 'active' : 'inactive'
-									}
-								>
-									Statistics
 								</a>
 							</Link>
 						</li>

--- a/components/IPOs/IPOSources.tsx
+++ b/components/IPOs/IPOSources.tsx
@@ -1,6 +1,6 @@
 export function IPOSources() {
 	return (
-		<div className="text-sm text-gray-70 pt-2 sm:pt-0">
+		<div className="text-sm text-gray-700 pt-2 sm:pt-0">
 			<span className="font-medium">Sources:</span> Most data is sourced from
 			the S-1 and S-1/A filings that companies submit to the U.S. Securities
 			and Exchange Commission (

--- a/components/IPOs/IPOSources.tsx
+++ b/components/IPOs/IPOSources.tsx
@@ -1,0 +1,20 @@
+export function IPOSources() {
+	return (
+		<div className="text-sm text-gray-70 pt-2 sm:pt-0">
+			<span className="font-medium">Sources:</span> Most data is sourced from
+			the S-1 and S-1/A filings that companies submit to the U.S. Securities
+			and Exchange Commission (
+			<a
+				href="https://www.sec.gov/cgi-bin/browse-edgar?company=&CIK=&type=s-1&owner=include&count=40&action=getcurrent"
+				target="_blank"
+				rel="noopener noreferrer"
+				className="bll"
+			>
+				SEC
+			</a>
+			). IPO dates are sourced from SEC filings, press releases, roadshow
+			presentations, NASDAQ, NYSE and others. IPO dates are estimated and may
+			change, and in some cases companies postpone or withdraw their plans.
+		</div>
+	);
+}

--- a/components/IPOs/LaterExplanation.tsx
+++ b/components/IPOs/LaterExplanation.tsx
@@ -2,7 +2,7 @@ import { Information } from 'components/Alerts/Information';
 
 export function LaterExplanation() {
 	return (
-		<div>
+		<div className="pb-1 lg:pb-0">
 			<h2 className="hh2 text-[1.4rem] leading-none text-gray-800 mb-4">
 				After Next Week
 			</h2>

--- a/components/IPOs/LaterExplanation.tsx
+++ b/components/IPOs/LaterExplanation.tsx
@@ -1,0 +1,15 @@
+import { Information } from 'components/Alerts/Information';
+
+export function LaterExplanation() {
+	return (
+		<div>
+			<h2 className="hh2 text-[1.4rem] leading-none text-gray-800 mb-4">
+				After Next Week
+			</h2>
+			<Information
+				message="No IPO dates have been set later than next week. The reason is that IPO dates are rarely scheduled more than 1-2 weeks in advance. Below is a list of all the companies that have filed papers to go public but do not have a set IPO date yet."
+				classes="text-base sm:text-[1.05rem] text-blue-800 mb-1"
+			/>
+		</div>
+	);
+}

--- a/components/IPOs/LaterExplanation.tsx
+++ b/components/IPOs/LaterExplanation.tsx
@@ -3,7 +3,7 @@ import { Information } from 'components/Alerts/Information';
 export function LaterExplanation() {
 	return (
 		<div className="pb-1 lg:pb-0">
-			<h2 className="hh2 text-[1.4rem] leading-none text-gray-800 mb-4">
+			<h2 className="hh2 text-[1.4rem] text-gray-800 mb-4">
 				After Next Week
 			</h2>
 			<Information

--- a/components/IPOs/LaterExplanation.tsx
+++ b/components/IPOs/LaterExplanation.tsx
@@ -7,7 +7,7 @@ export function LaterExplanation() {
 				After Next Week
 			</h2>
 			<Information
-				message="No IPO dates have been set later than next week. The reason is that IPO dates are rarely scheduled more than 1-2 weeks in advance. Below is a list of all the companies that have filed papers to go public but do not have a set IPO date yet."
+				message="No IPO dates have been set later than next week. The reason is that IPO dates are rarely scheduled more than 7-10 days in advance. Below is a list of all the companies that have filed papers to go public but do not have a set IPO date yet."
 				classes="text-base sm:text-[1.05rem] text-blue-800 mb-1"
 			/>
 		</div>

--- a/components/IPOs/LaterExplanation.tsx
+++ b/components/IPOs/LaterExplanation.tsx
@@ -7,7 +7,7 @@ export function LaterExplanation() {
 				After Next Week
 			</h2>
 			<Information
-				message="No IPO dates have been set after next week. The reason is that IPO dates are rarely scheduled more than 7-10 days in advance. Below is a list of all the companies that have filed papers to go public but do not have a set date yet."
+				message="No IPO dates have been set after next week. The reason is that IPO dates are rarely scheduled more than 7-10 days in advance."
 				classes="text-base sm:text-[1.05rem] text-blue-800 mb-1"
 			/>
 		</div>

--- a/components/IPOs/LaterExplanation.tsx
+++ b/components/IPOs/LaterExplanation.tsx
@@ -7,7 +7,7 @@ export function LaterExplanation() {
 				After Next Week
 			</h2>
 			<Information
-				message="No IPO dates have been set later than next week. The reason is that IPO dates are rarely scheduled more than 7-10 days in advance. Below is a list of all the companies that have filed papers to go public but do not have a set IPO date yet."
+				message="No IPO dates have been set after next week. The reason is that IPO dates are rarely scheduled more than 7-10 days in advance. Below is a list of all the companies that have filed papers to go public but do not have a set date yet."
 				classes="text-base sm:text-[1.05rem] text-blue-800 mb-1"
 			/>
 		</div>

--- a/components/PriceChart/PriceChart.functions.tsx
+++ b/components/PriceChart/PriceChart.functions.tsx
@@ -5,14 +5,10 @@ export function getChartUrl(id: number, time: string, override: boolean) {
 	const params = `i=${id}&r=${time}&m=1`;
 
 	let apiurl;
-	if (time === '1D' || time === '5D') {
-		apiurl = `chart?i=${id}&r=${time}`;
-	} else if (override) {
-		apiurl = `c?${params}`;
-	} else if (time === '5Y' || time === 'MAX') {
-		apiurl = `cch?${params}&p=w`;
+	if (time === '5Y' || time === 'MAX') {
+		apiurl = `chart?${params}&p=w`;
 	} else {
-		apiurl = `cch?${params}&p=d`;
+		apiurl = `chart?${params}`;
 	}
 
 	return apiurl;

--- a/pages/ipos/calendar.tsx
+++ b/pages/ipos/calendar.tsx
@@ -4,7 +4,10 @@ import { CalendarData, IpoRecent } from 'types/Ipos';
 import { SEO } from 'components/SEO';
 import { getIpoData } from 'functions/callBackEnd';
 import { CalendarStats } from 'components/IPOs/CalendarStats';
+import { CalendarStatsMobile } from 'components/IPOs/CalendarStatsMobile';
 import { CalendarTable } from 'components/IPOs/CalendarTable';
+import { LaterExplanation } from 'components/IPOs/LaterExplanation';
+import { IPOSources } from 'components/IPOs/IPOSources';
 import { IPONavigation } from 'components/IPOs/IPONavigation';
 import { Breadcrumbs } from 'components/Breadcrumbs/_Breadcrumbs';
 import { RecentTableMin } from 'components/IPOs/RecentTableMin';
@@ -33,9 +36,10 @@ export const IpoCalendar = ({ data, news, recent }: Props) => {
 					<h1 className="hh1">IPO Calendar</h1>
 					<IPONavigation />
 					<div className="lg:grid lg:grid-cols-sidebar gap-x-10">
-						<div className="flex flex-col space-y-5 sm:space-y-7 py-4">
+						<CalendarStatsMobile data={data} />
+						<div className="flex flex-col space-y-4 sm:space-y-7 py-2 lg:py-4">
 							<CalendarTable
-								title="IPOs This Week"
+								title="This Week"
 								data={data.thisweek}
 								tableId="this-week"
 							/>
@@ -44,19 +48,24 @@ export const IpoCalendar = ({ data, news, recent }: Props) => {
 								data={data.nextweek}
 								tableId="next-week"
 							/>
-							<CalendarTable
-								title="Scheduled for Later"
-								data={data.later}
-								tableId="later"
-							/>
+							<IPOSources />
 							<Mobile1 />
+							{data.later.length ? (
+								<CalendarTable
+									title="Scheduled for Later"
+									data={data.later}
+									tableId="later"
+								/>
+							) : (
+								<LaterExplanation />
+							)}
 							<CalendarTable
 								title="Upcoming High-Profile IPOs"
 								data={data.highprofile}
 								tableId="high-profile"
 							/>
 							<CalendarTable
-								title="More Upcoming IPOs"
+								title="Unscheduled"
 								data={data.unknown}
 								tableId="more-upcoming"
 							/>

--- a/pages/ipos/calendar.tsx
+++ b/pages/ipos/calendar.tsx
@@ -48,8 +48,6 @@ export const IpoCalendar = ({ data, news, recent }: Props) => {
 								data={data.nextweek}
 								tableId="next-week"
 							/>
-							<IPOSources />
-							<Mobile1 />
 							{data.later.length ? (
 								<CalendarTable
 									title="Scheduled for Later"
@@ -59,6 +57,8 @@ export const IpoCalendar = ({ data, news, recent }: Props) => {
 							) : (
 								<LaterExplanation />
 							)}
+							<IPOSources />
+							<Mobile1 />
 							<CalendarTable
 								title="Upcoming High-Profile IPOs"
 								data={data.highprofile}


### PR DESCRIPTION
- Several improvements to the IPO calendar:
1. Now showing the "Calendar Statistics" on mobile
2. Added an "After Next Week" explainer about why there are no later IPO dates
3. Added a "Sources" snippet
4. Adjusted some headers, navigation tab order

- All stock price charts now use the new chart endpoint