### PR TITLE
Test getServerSideProps on several pages, lower revalidation times

### DIFF
--- a/pages/ipos/[year].tsx
+++ b/pages/ipos/[year].tsx
@@ -92,7 +92,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 			news,
 			upcoming,
 		},
-		revalidate: 4 * 60 * 60,
+		revalidate: 60 * 60,
 	}
 }
 

--- a/pages/ipos/calendar.tsx
+++ b/pages/ipos/calendar.tsx
@@ -1,4 +1,4 @@
-import { GetStaticProps } from 'next'
+import { GetServerSideProps } from 'next'
 import { CalendarData, IpoRecent, FilingMin } from 'types/Ipos'
 import { SEO } from 'components/SEO'
 import { getIpoData } from 'functions/callBackEnd'
@@ -82,7 +82,7 @@ export const IpoCalendar = ({ data, recent, filings }: Props) => {
 
 export default IpoCalendar
 
-export const getStaticProps: GetStaticProps = async () => {
+export const getServerSideProps: GetServerSideProps = async () => {
 	const { data, recent, filings } = await getIpoData('calendar')
 
 	return {
@@ -91,6 +91,5 @@ export const getStaticProps: GetStaticProps = async () => {
 			recent,
 			filings,
 		},
-		revalidate: 5 * 60,
 	}
 }

--- a/pages/ipos/statistics.tsx
+++ b/pages/ipos/statistics.tsx
@@ -142,6 +142,6 @@ export const getStaticProps: GetStaticProps = async () => {
 			news,
 			recent,
 		},
-		revalidate: 4 * 60 * 60,
+		revalidate: 2 * 60 * 60,
 	}
 }

--- a/pages/news/all-stocks.tsx
+++ b/pages/news/all-stocks.tsx
@@ -55,7 +55,7 @@ export const AllStockNews = ({ data, other }: Props) => {
 
 export default AllStockNews
 
-export const getServerSideProps: GetServerSideProps = async () => {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
 	const { data, other } = await getMarketNews('stocks')
 
 	return {

--- a/pages/news/all-stocks.tsx
+++ b/pages/news/all-stocks.tsx
@@ -1,4 +1,4 @@
-import { GetServerSideProps, GetStaticProps } from 'next'
+import { GetServerSideProps } from 'next'
 import { News } from 'types/News'
 import { SEO } from 'components/SEO'
 import { getMarketNews } from 'functions/callBackEnd'
@@ -54,18 +54,6 @@ export const AllStockNews = ({ data, other }: Props) => {
 }
 
 export default AllStockNews
-
-// export const getStaticProps: GetStaticProps = async () => {
-// 	const { data, other } = await getMarketNews('stocks');
-
-// 	return {
-// 		props: {
-// 			data,
-// 			other,
-// 		},
-// 		revalidate: 5 * 60,
-// 	};
-// };
 
 export const getServerSideProps: GetServerSideProps = async () => {
 	const { data, other } = await getMarketNews('stocks')

--- a/pages/news/all-stocks.tsx
+++ b/pages/news/all-stocks.tsx
@@ -1,17 +1,17 @@
-import { GetStaticProps } from 'next';
-import { News } from 'types/News';
-import { SEO } from 'components/SEO';
-import { getMarketNews } from 'functions/callBackEnd';
-import { NewsNavigation } from 'components/News/NewsNavigation';
-import { Breadcrumbs } from 'components/Breadcrumbs/_Breadcrumbs';
-import { NewsFeed } from 'components/News/_NewsFeed';
-import { NewsWidget } from 'components/News/NewsWidget';
-import { Sidebar1 } from 'components/Ads/Snigel/Sidebar1';
-import { Sidebar2 } from 'components/Ads/Snigel/Sidebar2';
+import { GetServerSideProps, GetStaticProps } from 'next'
+import { News } from 'types/News'
+import { SEO } from 'components/SEO'
+import { getMarketNews } from 'functions/callBackEnd'
+import { NewsNavigation } from 'components/News/NewsNavigation'
+import { Breadcrumbs } from 'components/Breadcrumbs/_Breadcrumbs'
+import { NewsFeed } from 'components/News/_NewsFeed'
+import { NewsWidget } from 'components/News/NewsWidget'
+import { Sidebar1 } from 'components/Ads/Snigel/Sidebar1'
+import { Sidebar2 } from 'components/Ads/Snigel/Sidebar2'
 
 interface Props {
-	data: News[];
-	other: News[];
+	data: News[]
+	other: News[]
 }
 
 export const AllStockNews = ({ data, other }: Props) => {
@@ -50,19 +50,30 @@ export const AllStockNews = ({ data, other }: Props) => {
 				</main>
 			</div>
 		</>
-	);
-};
+	)
+}
 
-export default AllStockNews;
+export default AllStockNews
 
-export const getStaticProps: GetStaticProps = async () => {
-	const { data, other } = await getMarketNews('stocks');
+// export const getStaticProps: GetStaticProps = async () => {
+// 	const { data, other } = await getMarketNews('stocks');
+
+// 	return {
+// 		props: {
+// 			data,
+// 			other,
+// 		},
+// 		revalidate: 5 * 60,
+// 	};
+// };
+
+export const getServerSideProps: GetServerSideProps = async () => {
+	const { data, other } = await getMarketNews('stocks')
 
 	return {
 		props: {
 			data,
 			other,
 		},
-		revalidate: 5 * 60,
-	};
-};
+	}
+}

--- a/pages/news/index.tsx
+++ b/pages/news/index.tsx
@@ -1,17 +1,17 @@
-import { GetStaticProps } from 'next';
-import { News } from 'types/News';
-import { SEO } from 'components/SEO';
-import { getMarketNews } from 'functions/callBackEnd';
-import { NewsNavigation } from 'components/News/NewsNavigation';
-import { Breadcrumbs } from 'components/Breadcrumbs/_Breadcrumbs';
-import { NewsFeed } from 'components/News/_NewsFeed';
-import { NewsWidget } from 'components/News/NewsWidget';
-import { Sidebar1 } from 'components/Ads/Snigel/Sidebar1';
-import { Sidebar2 } from 'components/Ads/Snigel/Sidebar2';
+import { GetServerSideProps } from 'next'
+import { News } from 'types/News'
+import { SEO } from 'components/SEO'
+import { getMarketNews } from 'functions/callBackEnd'
+import { NewsNavigation } from 'components/News/NewsNavigation'
+import { Breadcrumbs } from 'components/Breadcrumbs/_Breadcrumbs'
+import { NewsFeed } from 'components/News/_NewsFeed'
+import { NewsWidget } from 'components/News/NewsWidget'
+import { Sidebar1 } from 'components/Ads/Snigel/Sidebar1'
+import { Sidebar2 } from 'components/Ads/Snigel/Sidebar2'
 
 interface Props {
-	data: News[];
-	other: News[];
+	data: News[]
+	other: News[]
 }
 
 export const MarketNews = ({ data, other }: Props) => {
@@ -50,19 +50,18 @@ export const MarketNews = ({ data, other }: Props) => {
 				</main>
 			</div>
 		</>
-	);
-};
+	)
+}
 
-export default MarketNews;
+export default MarketNews
 
-export const getStaticProps: GetStaticProps = async () => {
-	const { data, other } = await getMarketNews('market');
+export const getServerSideProps: GetServerSideProps = async () => {
+	const { data, other } = await getMarketNews('stocks')
 
 	return {
 		props: {
 			data,
 			other,
 		},
-		revalidate: 5 * 60,
-	};
-};
+	}
+}

--- a/pages/news/press-releases.tsx
+++ b/pages/news/press-releases.tsx
@@ -1,4 +1,4 @@
-import { GetStaticProps } from 'next'
+import { GetServerSideProps } from 'next'
 import { News } from 'types/News'
 import { SEO } from 'components/SEO'
 import { getMarketNews } from 'functions/callBackEnd'
@@ -55,14 +55,13 @@ export const AllPressReleases = ({ data, other }: Props) => {
 
 export default AllPressReleases
 
-export const getStaticProps: GetStaticProps = async () => {
-	const { data, other } = await getMarketNews('press')
+export const getServerSideProps: GetServerSideProps = async () => {
+	const { data, other } = await getMarketNews('stocks')
 
 	return {
 		props: {
 			data,
 			other,
 		},
-		revalidate: 10 * 60,
 	}
 }

--- a/pages/stocks/[symbol]/index.tsx
+++ b/pages/stocks/[symbol]/index.tsx
@@ -75,7 +75,7 @@ interface IParams extends ParsedUrlQuery {
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
 	const { symbol } = params as IParams
-	return await getPageData('overview', symbol, 10 * 60, 'stocks')
+	return await getPageData('overview', symbol, 5 * 60, 'stocks')
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {


### PR DESCRIPTION
- Use getServerSideProps on news, IPO calendar
- Reduce ISR revalidation times on a few other pages