### PR TITLE
Stock Tables and Historical IPOs

### DIFF
--- a/.vscode/snippets.code-snippets
+++ b/.vscode/snippets.code-snippets
@@ -31,9 +31,9 @@
 		"description": "className"
 	},
 	"Function - Export": {
-		"prefix": "funed",
+		"prefix": "fune",
 		"body": [
-			"export default function ${1:name}(${2:props}) {",
+			"export function ${1:name}(${2:props}) {",
 			"\treturn (${3});",
 			"}"
 		],

--- a/components/Dropdown/SelectColumns/ClearColumns.tsx
+++ b/components/Dropdown/SelectColumns/ClearColumns.tsx
@@ -1,0 +1,14 @@
+import { CloseCircleIcon } from 'components/Icons/CloseCircle'
+
+export function ClearColumns({ clear }: { clear: () => void }) {
+	return (
+		<div
+			className="flex items-center border-t border-gray-300 cursor-pointer py-1 px-2 text-sm font-semibold text-gray-600 hover:text-red-600"
+			onClick={() => clear()}
+			title="Reset selected columns"
+		>
+			<CloseCircleIcon classes="w-4 h-4 mr-1" />
+			Reset columns
+		</div>
+	)
+}

--- a/components/Dropdown/SelectColumns/ColumnList.tsx
+++ b/components/Dropdown/SelectColumns/ColumnList.tsx
@@ -18,7 +18,7 @@ export function ColumnList({ _active, options, search, toggle }: Props) {
 	// check which data points are active vs. inactive
 	options.forEach(item => {
 		let { id, name } = DataPoints[item]
-		if (id !== 's' && id !== 'n') {
+		if (id !== 's') {
 			if (_active.includes(item)) active.push({ id, name })
 			else inactive.push({ id, name })
 		}

--- a/components/Dropdown/SelectColumns/_SelectColumns.tsx
+++ b/components/Dropdown/SelectColumns/_SelectColumns.tsx
@@ -1,6 +1,7 @@
 import { Dropdown } from 'components/Dropdown/_Dropdown'
 import { useState } from 'react'
 import { DataId } from 'types/DataId'
+import { ClearColumns } from './ClearColumns'
 import { ColumnList } from './ColumnList'
 import { ColumnSearch } from './ColumnSearch'
 
@@ -8,9 +9,17 @@ type Props = {
 	active: DataId[]
 	options: DataId[]
 	toggle: (id: DataId) => void
+	clear: () => void
+	enabled: boolean
 }
 
-export function SelectColumns({ active, options, toggle }: Props) {
+export function SelectColumns({
+	active,
+	options,
+	toggle,
+	clear,
+	enabled
+}: Props) {
 	const [search, setSearch] = useState<string>('')
 
 	return (
@@ -22,6 +31,7 @@ export function SelectColumns({ active, options, toggle }: Props) {
 				search={search}
 				toggle={toggle}
 			/>
+			{enabled && <ClearColumns clear={clear} />}
 		</Dropdown>
 	)
 }

--- a/components/Markets/_MarketsLayout.tsx
+++ b/components/Markets/_MarketsLayout.tsx
@@ -18,7 +18,7 @@ export function MarketsLayout({ children }: Props) {
 				canonical={page.path}
 			/>
 			<div className="contain">
-				<h1 className="hh1">{page.parentTitle || page.title}</h1>
+				<h1 className="hh1">{page.pageTitle}</h1>
 				<MarketsNavigation active={page.active || 'inactive'} />
 				{children}
 			</div>

--- a/components/StockScreener/functions/sort/sortFunctions.tsx
+++ b/components/StockScreener/functions/sort/sortFunctions.tsx
@@ -1,4 +1,12 @@
 import { Row } from 'react-table'
+import { DataId } from 'types/DataId'
+
+export function number(a: Row, b: Row, id: DataId) {
+	let aa = Math.abs(a.values[id])
+	let bb = Math.abs(b.values[id])
+
+	return aa - bb
+}
 
 export const priceSort = (a: Row, b: Row) => {
 	const splitA = a.values.ipoPriceRange.split(/(\s+)/)

--- a/components/StockTable/Controls/TableColumns.tsx
+++ b/components/StockTable/Controls/TableColumns.tsx
@@ -4,7 +4,8 @@ import { DataId } from 'types/DataId'
 import { useTableContext } from '../TableContext'
 
 export function TableColumns() {
-	const { type, fixed, dynamic, setState } = useTableContext()
+	const { type, fixed, dynamic, setState, clearState, enabled } =
+		useTableContext()
 	const { columnOptions, excludeColumns } = fixed
 	const { main, columns } = dynamic
 
@@ -23,5 +24,13 @@ export function TableColumns() {
 		})
 	}
 
-	return <SelectColumns active={cols} options={colSelect} toggle={toggle} />
+	return (
+		<SelectColumns
+			active={cols}
+			options={colSelect}
+			toggle={toggle}
+			clear={clearState}
+			enabled={enabled}
+		/>
+	)
 }

--- a/components/StockTable/Controls/TableExport.tsx
+++ b/components/StockTable/Controls/TableExport.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export function TableExport({ tableId }: Props) {
 	return (
-		<div className="hidden md:block">
+		<div className="controls-export">
 			<Export
 				buttons={[
 					{

--- a/components/StockTable/Controls/TableResults.tsx
+++ b/components/StockTable/Controls/TableResults.tsx
@@ -46,7 +46,7 @@ export function TableResults() {
 	}
 
 	// the text on the dropdown button
-	let title = count.toString() + ' Rows'
+	let title = count ? count.toString() + ' Rows' : 'Rows'
 
 	return (
 		<Dropdown title={title} hoverTitle="Change results count">
@@ -54,7 +54,7 @@ export function TableResults() {
 				/* One Dropdown Item */
 				<div
 					key={i.value}
-					className={cn('dd-option', tabActive(i.value, count))}
+					className={cn('dd-option', tabActive(i.value, count || 0))}
 					title={hoverTitle(i.value, i.pro)}
 					onClick={() => handleClick(i.value, i.pro)}
 				>

--- a/components/StockTable/Controls/TableTitle.tsx
+++ b/components/StockTable/Controls/TableTitle.tsx
@@ -2,24 +2,24 @@ import { useTableContext } from '../TableContext'
 
 type Props = {
 	title: string
-	active?: string
+	tableId?: string
 }
 
-export function TableTitle({ title, active }: Props) {
+export function TableTitle({ title, tableId }: Props) {
 	const { dynamic } = useTableContext()
 	const { main, sortDirection } = dynamic
 
 	let printTitle = title
 
 	// Change the title from "Today" if a different time range is selected
-	if ((active === 'gainers' || active === 'losers') && main !== 'change') {
+	if ((tableId === 'gainers' || tableId === 'losers') && main !== 'change') {
 		printTitle = printTitle.replace(
 			/Today/,
 			main.replace(/ch/, '').toUpperCase()
 		)
 	}
 
-	if (active === 'premarket' && sortDirection === 'asc') {
+	if (tableId === 'premarket' && sortDirection === 'asc') {
 		printTitle = printTitle.replace('Gainers', 'Losers')
 	}
 

--- a/components/StockTable/TableContext.tsx
+++ b/components/StockTable/TableContext.tsx
@@ -12,6 +12,7 @@ interface InitialProps {
 
 interface ContextProps extends InitialProps {
 	setState: (newState: Partial<TableDynamic>) => void // Set the table state
+	clearState: () => void // Clear the table state
 	enabled: boolean // Whether react-query fetching is enabled
 }
 
@@ -22,36 +23,32 @@ type ProviderProps = {
 	children: React.ReactNode
 }
 
-let parsed: {
-	stored: TableDynamic | null
-	tableId: string
-} = {
-	stored: null,
-	tableId: ''
-}
+// Store data from localStorage outside of the component state
+// This is used to persist the table state between page views
+// without having to fetch from localStorage again
+let parsed: any = {}
 
 export function TableContextProvider({ value, children }: ProviderProps) {
-	const initialState = value.dynamic
+	const { dynamic: initial, tableId: id } = value
 	const [enabled, setEnabled] = useState(false)
-	const [dynamic, setDynamic] = useState(
-		value.tableId === parsed.tableId && parsed.stored
-			? parsed.stored
-			: initialState
-	)
+	const [dynamic, setDynamic] = useState(parsed?.[id] || initial)
 
 	// Recover the state from localStorage, if it exists
 	useEffect(() => {
-		let stored = localStorage.getItem(value.tableId)
+		let stored = localStorage.getItem(id)
 		if (stored) {
 			let obj = JSON.parse(stored)
 			if (obj) {
-				parsed.tableId = value.tableId
-				parsed.stored = obj
+				parsed[id] = obj
 				setDynamic(obj)
 				setEnabled(true)
 			}
+		} else {
+			parsed[id] = null
+			setDynamic(initial)
+			setEnabled(false)
 		}
-	}, [initialState, value.tableId])
+	}, [id, initial])
 
 	// Update the table state
 	// Then save it in localStorage
@@ -62,27 +59,35 @@ export function TableContextProvider({ value, children }: ProviderProps) {
 
 		let stringified = objString(combined)
 		// If both objects are equal, delete the entry from localStorage
-		if (stringified === objString(initialState)) {
-			localStorage.removeItem(value.tableId)
-			parsed.tableId = value.tableId
+		if (stringified === objString(initial)) {
+			localStorage.removeItem(id)
+			parsed.tableId = id
 			parsed.stored = null
 			// If they are not equal, save current state to localStorage
 		} else {
 			setEnabled(true)
-			localStorage.setItem(value.tableId, stringified)
-			parsed.tableId = value.tableId
+			localStorage.setItem(id, stringified)
+			parsed.tableId = id
 			parsed.stored = combined
 		}
+	}
+
+	function clearState() {
+		localStorage.removeItem(id)
+		parsed.tableId = id
+		parsed.stored = null
+		setDynamic(initial)
 	}
 
 	// The full state to pass as context
 	const state = {
 		type: value.type,
 		title: value.title,
-		tableId: value.tableId,
+		tableId: id,
 		fixed: value.fixed,
 		dynamic,
 		setState,
+		clearState,
 		enabled
 	}
 

--- a/components/StockTable/TableContext.tsx
+++ b/components/StockTable/TableContext.tsx
@@ -4,6 +4,7 @@ import { TableDynamic, TableFixed } from './TableTypes'
 
 interface InitialProps {
 	type: 'stocks' | 'etf' // The symbol type
+	title: string // The title of the table
 	tableId: string // The unique ID for the table
 	fixed: TableFixed // Table data that does not change
 	dynamic: TableDynamic // Table data that becomes state and changes
@@ -77,6 +78,7 @@ export function TableContextProvider({ value, children }: ProviderProps) {
 	// The full state to pass as context
 	const state = {
 		type: value.type,
+		title: value.title,
 		tableId: value.tableId,
 		fixed: value.fixed,
 		dynamic,

--- a/components/StockTable/TableContext.tsx
+++ b/components/StockTable/TableContext.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext, useEffect, useState } from 'react'
 import { TableDynamic, TableFixed } from './TableTypes'
 
 interface InitialProps {
-	type: 'stocks' | 'etf' // The symbol type
+	type: 'stocks' | 'etf' | 'histip' // The stock index type (more specific is faster)
 	title: string // The title of the table
 	tableId: string // The unique ID for the table
 	fixed: TableFixed // Table data that does not change

--- a/components/StockTable/TableTypes.ts
+++ b/components/StockTable/TableTypes.ts
@@ -24,7 +24,7 @@ export type TableFixed = {
 export type TableDynamic = {
 	main: DataId // The main column to sort by
 
-	count: number // The number of symbols to show
+	count?: number // The number of symbols to show -- if empty, show all
 
 	sort?: SortObject[] // What is currently sorted by
 	sortDirection: 'desc' | 'asc' // The sort order

--- a/components/StockTable/TableTypes.ts
+++ b/components/StockTable/TableTypes.ts
@@ -17,6 +17,7 @@ export type TableFixed = {
 
 	columnOptions?: DataId[] // The columns available to select
 	excludeColumns?: DataId[] // Columns to exclude
+	columnOrder?: DataId[] // The order of the columns
 }
 
 // Dynamic data that becomes state and is used to modify the table

--- a/components/StockTable/_StockTableBody.tsx
+++ b/components/StockTable/_StockTableBody.tsx
@@ -5,7 +5,8 @@ import {
 	useTable,
 	useSortBy,
 	useGlobalFilter,
-	useAsyncDebounce
+	useAsyncDebounce,
+	useColumnOrder
 } from 'react-table'
 import { DataId } from 'types/DataId'
 import { StockTableControls } from './_StockTableControls'
@@ -20,9 +21,18 @@ type Props = {
 	}[]
 	sortProps: SortProps
 	sort?: SortObject[]
+	tableId: string
+	columnOrder?: DataId[]
 }
 
-export function StockTableBody({ data, columns, sortProps, sort }: Props) {
+export function StockTableBody({
+	data,
+	columns,
+	sortProps,
+	sort,
+	tableId,
+	columnOrder
+}: Props) {
 	const [search, setSearch] = useState('')
 	const { updateSort } = useSort(sortProps)
 
@@ -31,18 +41,19 @@ export function StockTableBody({ data, columns, sortProps, sort }: Props) {
 			columns,
 			data,
 			initialState: {
-				sortBy: sort && sort.length ? sort : sortProps.defaultSort
+				sortBy: sort && sort.length ? sort : sortProps.defaultSort,
+				columnOrder: columnOrder || []
 			}
 		},
 		useGlobalFilter,
-		useSortBy
+		useSortBy,
+		useColumnOrder
 	)
 
 	return (
 		<div>
 			<div className="mt-3 sm:mt-0">
 				<StockTableControls
-					tableId="stock-table"
 					filter={{
 						useAsyncDebounce,
 						setGlobalFilter,
@@ -52,7 +63,7 @@ export function StockTableBody({ data, columns, sortProps, sort }: Props) {
 				/>
 			</div>
 			<div className="overflow-x-auto">
-				<table className="symbol-table stock-table" id="stock-table">
+				<table className="symbol-table stock-table" id={tableId}>
 					<thead>
 						{headerGroups.map((headerGroup, index) => (
 							<tr key={index}>

--- a/components/StockTable/_StockTableControls.tsx
+++ b/components/StockTable/_StockTableControls.tsx
@@ -12,18 +12,17 @@ import { useTableContext } from './TableContext'
 
 type Props = {
 	filter: FilterObject
-	tableId: string
 }
 
-export function StockTableControls({ filter, tableId }: Props) {
-	const { fixed } = useTableContext()
-	const { page, updated } = usePageContext()
+export function StockTableControls({ filter }: Props) {
+	const { fixed, tableId, title } = useTableContext()
+	const { updated } = usePageContext()
 
 	return (
 		<div className="controls groups">
 			<div className="title-group">
 				{/* Table Title */}
-				<TableTitle title={page.title} active={page.active} />
+				<TableTitle title={title} tableId={tableId} />
 				{/* Updated timestamp*/}
 				{updated && <TableTimestamp />}
 			</div>

--- a/components/StockTable/__StockTable.tsx
+++ b/components/StockTable/__StockTable.tsx
@@ -21,7 +21,7 @@ export function StockTable({ _data }: { _data: any[] }) {
 	const query = useTableData(tableId, type, dynamic, _data, enabled)
 
 	// memoize the data and columns
-	const data = useMemo(() => query.data.data || query.data, [query.data])
+	const data = useMemo(() => query?.data?.data || query?.data, [query.data])
 	const columns = useMemo(() => getColumns(_columns, main), [_columns, main])
 
 	const sortProps = useMemo(

--- a/components/StockTable/__StockTable.tsx
+++ b/components/StockTable/__StockTable.tsx
@@ -14,7 +14,7 @@ export function StockTable({ _data }: { _data: any[] }) {
 		useTableContext()
 
 	// Get the props
-	const { defaultSort } = fixed
+	const { defaultSort, columnOrder } = fixed
 	const { columns: _columns, main, sort } = dynamic
 
 	// pass initial data into react query
@@ -36,6 +36,8 @@ export function StockTable({ _data }: { _data: any[] }) {
 			columns={columns}
 			sortProps={sortProps}
 			sort={sort}
+			columnOrder={columnOrder}
+			tableId={tableId}
 		/>
 	)
 }

--- a/components/StockTable/getColumns.ts
+++ b/components/StockTable/getColumns.ts
@@ -15,7 +15,7 @@ export function getColumns(cols: DataId[], main: DataId) {
 
 	const columns = newCols.map(col => {
 		// destructure the data points
-		let { name, colName, format } = DataPoints[col]
+		let { name, colName, format, sort } = DataPoints[col]
 
 		// Header: the name of the column, shown
 		// accessor: the id of the column, not shown
@@ -30,6 +30,7 @@ export function getColumns(cols: DataId[], main: DataId) {
 					? props.value
 					: '-'
 			},
+			sortType: sort || 'basic',
 			sortInverted:
 				col !== main && format !== 'string' && format !== 'linkSymbol'
 					? true

--- a/components/StockTable/useTableData.ts
+++ b/components/StockTable/useTableData.ts
@@ -1,5 +1,6 @@
 import { getSelect } from 'functions/apis/getSelect'
 import { useQuery } from 'react-query'
+import { IndexType } from 'types/Tables'
 import { TableDynamic } from './TableTypes'
 
 /**
@@ -7,7 +8,7 @@ import { TableDynamic } from './TableTypes'
  */
 export function useTableData(
 	tableId: string,
-	type: 'stocks' | 'etf',
+	type: IndexType,
 	dynamic: TableDynamic,
 	_data: any[],
 	enabled?: boolean

--- a/components/Tables/HeaderCell.tsx
+++ b/components/Tables/HeaderCell.tsx
@@ -15,7 +15,7 @@ export function HeaderCell({ column, updateSort }: Props) {
 	const { format, name } = DataPoints[id]
 
 	let css =
-		format && ['string', 'linkSymbol'].includes(format)
+		format && ['string', 'linkSymbol', 'linkName'].includes(format)
 			? 'head-left'
 			: 'head-right'
 

--- a/data/StockDataPoints.tsx
+++ b/data/StockDataPoints.tsx
@@ -171,6 +171,23 @@ export const DataPoints: Props = {
 		format: 'formatDate',
 		sort: dateSort
 	},
+	ipp: {
+		id: 'ipp',
+		name: 'IPO Price',
+		format: 'price'
+	},
+	ippc: {
+		id: 'ippc',
+		name: 'Current Price',
+		colName: 'Current',
+		format: 'price'
+	},
+	ipr: {
+		id: 'ipr',
+		colName: 'Return',
+		name: 'Return Since IPO',
+		format: 'colorPercentage'
+	},
 	revenue: { id: 'revenue', name: 'Revenue', format: 'abbreviate' },
 	revenueGrowth: {
 		id: 'revenueGrowth',

--- a/data/StockDataPoints.tsx
+++ b/data/StockDataPoints.tsx
@@ -1,6 +1,9 @@
 import { DataId } from 'types/DataId'
-import { FormatFunction } from 'types/Tables'
-import { dateSort } from 'components/StockScreener/functions/sort/sortFunctions'
+import { FormatFunction, IndexType } from 'types/Tables'
+import {
+	number,
+	dateSort
+} from 'components/StockScreener/functions/sort/sortFunctions'
 
 type SymbolType = 'stocks' | 'ipo' | 'etf'
 
@@ -18,7 +21,7 @@ type Props = {
 }
 
 // Get a list of data point IDs to use for a table
-export function getDataPointsArray(type: SymbolType, exclude?: DataId[]) {
+export function getDataPointsArray(type: IndexType, exclude?: DataId[]) {
 	// get all the matching IDs from the DataPoints array of objects
 	let ids = Object.values(DataPoints)
 		.filter(f => !f.only || f.only === type)
@@ -56,7 +59,8 @@ export const DataPoints: Props = {
 		id: 'change',
 		name: 'Price Change 1D',
 		colName: '% Change',
-		format: 'colorPercentage'
+		format: 'colorPercentage',
+		sort: number
 	},
 	volume: { id: 'volume', name: 'Volume', format: 'integer' },
 	close: {
@@ -81,7 +85,8 @@ export const DataPoints: Props = {
 		id: 'premarketChangePercent',
 		name: 'Premarket % Change',
 		colName: '% Change',
-		format: 'colorPercentage'
+		format: 'colorPercentage',
+		sort: number
 	},
 	enterpriseValue: {
 		id: 'enterpriseValue',
@@ -159,12 +164,14 @@ export const DataPoints: Props = {
 	},
 	priceTargetChange: {
 		id: 'priceTargetChange',
-		name: 'Price Target (%)',
-		format: 'formatPercentage'
+		name: 'Price Target Difference (%)',
+		colName: 'PT Diff. (%)',
+		format: 'colorPercentage'
 	},
 	country: { id: 'country', name: 'Country', format: 'string' },
 	employees: { id: 'employees', name: 'Employees', format: 'integer' },
 	founded: { id: 'founded', name: 'Founded', format: 'string' },
+	/* IPO INFO */
 	ipoDate: {
 		id: 'ipoDate',
 		name: 'IPO Date',
@@ -187,6 +194,11 @@ export const DataPoints: Props = {
 		colName: 'Return',
 		name: 'Return Since IPO',
 		format: 'colorPercentage'
+	},
+	sharesOffered: {
+		id: 'sharesOffered',
+		name: 'Shares Offered',
+		format: 'integer'
 	},
 	revenue: { id: 'revenue', name: 'Revenue', format: 'abbreviate' },
 	revenueGrowth: {
@@ -516,12 +528,6 @@ export const DataPoints: Props = {
 		only: 'ipo'
 	},
 	isSpac: { id: 'isSpac', name: 'Is SPAC' },
-	sharesOffered: {
-		id: 'sharesOffered',
-		name: 'Shares Offered',
-		format: 'integer',
-		only: 'ipo'
-	},
 	aum: {
 		id: 'aum',
 		name: 'Assets Under Management',

--- a/data/StockDataPoints.tsx
+++ b/data/StockDataPoints.tsx
@@ -164,7 +164,7 @@ export const DataPoints: Props = {
 	},
 	priceTargetChange: {
 		id: 'priceTargetChange',
-		name: 'Price Target Difference (%)',
+		name: 'Price Target Diff. (%)',
 		colName: 'PT Diff. (%)',
 		format: 'colorPercentage'
 	},

--- a/data/StockDataPoints.tsx
+++ b/data/StockDataPoints.tsx
@@ -1,5 +1,6 @@
 import { DataId } from 'types/DataId'
 import { FormatFunction } from 'types/Tables'
+import { dateSort } from 'components/StockScreener/functions/sort/sortFunctions'
 
 type SymbolType = 'stocks' | 'ipo' | 'etf'
 
@@ -9,6 +10,7 @@ export type DataPointType = {
 	colName?: string
 	format?: FormatFunction
 	only?: SymbolType
+	sort?: any
 }
 
 type Props = {
@@ -36,7 +38,7 @@ export function getDataPointsArray(type: SymbolType, exclude?: DataId[]) {
  */
 export const DataPoints: Props = {
 	s: { id: 's', name: 'Symbol', format: 'linkSymbol' },
-	n: { id: 'n', name: 'Name', format: 'string' },
+	n: { id: 'n', name: 'Company Name', format: 'string' },
 	marketCap: { id: 'marketCap', name: 'Market Cap', format: 'abbreviate' },
 	price: {
 		id: 'price',
@@ -163,7 +165,12 @@ export const DataPoints: Props = {
 	country: { id: 'country', name: 'Country', format: 'string' },
 	employees: { id: 'employees', name: 'Employees', format: 'integer' },
 	founded: { id: 'founded', name: 'Founded', format: 'string' },
-	ipoDate: { id: 'ipoDate', name: 'IPO Date', format: 'formatDate' },
+	ipoDate: {
+		id: 'ipoDate',
+		name: 'IPO Date',
+		format: 'formatDate',
+		sort: dateSort
+	},
 	revenue: { id: 'revenue', name: 'Revenue', format: 'abbreviate' },
 	revenueGrowth: {
 		id: 'revenueGrowth',

--- a/functions/apis/getSelect.ts
+++ b/functions/apis/getSelect.ts
@@ -7,7 +7,7 @@ import { respondSSR } from './callBackEnd'
  */
 export async function getSelect(
 	config: TableDynamic,
-	type: 'stocks' | 'etf',
+	type: 'stocks' | 'etf' | 'histip',
 	ssr?: boolean,
 	extras?: string[]
 ) {

--- a/functions/apis/getSelect.ts
+++ b/functions/apis/getSelect.ts
@@ -8,7 +8,8 @@ import { respondSSR } from './callBackEnd'
 export async function getSelect(
 	config: TableDynamic,
 	type: 'stocks' | 'etf',
-	ssr?: boolean
+	ssr?: boolean,
+	extras?: string[]
 ) {
 	// destructure the props and create the URL
 	let { main, count, sortDirection, columns } = config
@@ -22,6 +23,11 @@ export async function getSelect(
 
 	// create the url
 	let url = `select?type=${type}&main=${main}&count=${count}&sort=${sortDirection}&columns=${cols}&filters=${filters}`
+
+	// request extra data
+	if (extras) {
+		url += `&extras=${extras.join(',')}`
+	}
 
 	// fetch the data from the back-end
 	let response = await getData(url)

--- a/functions/tables/formatCells.tsx
+++ b/functions/tables/formatCells.tsx
@@ -28,6 +28,7 @@ export function formatHeader(fn: Fn, value: string) {
 
 export function formatCells(fn: Fn, cell: Cell, type: Type = 'stocks') {
 	if (fn === 'linkSymbol') return formatSymbol(cell as CellString, type)
+	if (fn === 'linkName') return formatName(cell as CellString, type)
 	if (fn === 'format2dec') return format2dec(cell as CellNumber)
 	if (fn === 'integer') return formatInteger(cell as CellNumber)
 	if (fn === 'formatPercentage') return formatPercentage(cell as CellNumber)
@@ -49,6 +50,23 @@ export function formatSymbol(cell: CellString, type: ScreenerTypes) {
 		<Link href={url} prefetch={false}>
 			<a>{value}</a>
 		</Link>
+	)
+}
+
+// Turn a symbol into a link to the overview page
+export function formatName(cell: any, type: ScreenerTypes) {
+	let urlPath = type === 'etf' ? 'etf' : 'stocks'
+	let { value } = cell.cell
+	let ticker = cell.row.values.s
+	let symbol = ticker.includes('.') ? ticker : `${ticker}/`
+	let url = `/${urlPath}/${symbol.toLowerCase()}`
+
+	return (
+		<div className="string-left">
+			<Link href={url} prefetch={false}>
+				<a>{value}</a>
+			</Link>
+		</div>
 	)
 }
 

--- a/functions/tables/formatCells.tsx
+++ b/functions/tables/formatCells.tsx
@@ -30,6 +30,7 @@ export function formatCells(fn: Fn, cell: Cell, type: Type = 'stocks') {
 	if (fn === 'linkSymbol') return formatSymbol(cell as CellString, type)
 	if (fn === 'linkName') return formatName(cell as CellString, type)
 	if (fn === 'format2dec') return format2dec(cell as CellNumber)
+	if (fn === 'price') return formatPrice(cell as CellNumber)
 	if (fn === 'integer') return formatInteger(cell as CellNumber)
 	if (fn === 'formatPercentage') return formatPercentage(cell as CellNumber)
 	if (fn === 'colorPercentage') return colorPercentage(cell as CellNumber)
@@ -43,6 +44,7 @@ export function formatCells(fn: Fn, cell: Cell, type: Type = 'stocks') {
 export function formatSymbol(cell: CellString, type: ScreenerTypes) {
 	let urlPath = type === 'etf' ? 'etf' : 'stocks'
 	let { value } = cell.cell
+	if (value.startsWith('=')) return value.slice(1)
 	let symbol = value.includes('.') ? value : `${value}/`
 	let url = `/${urlPath}/${symbol.toLowerCase()}`
 
@@ -74,6 +76,12 @@ export function formatName(cell: any, type: ScreenerTypes) {
 export function format2dec(cell: CellNumber) {
 	let { value } = cell.cell
 	return <div className="text-right">{format(value, 2)}</div>
+}
+
+// Format a number with comma and 2 decimal points
+export function formatPrice(cell: CellNumber) {
+	let { value } = cell.cell
+	return value ? <div className="text-right">${format(value, 2)}</div> : 'n/a'
 }
 
 // Format an integer with comma and 0 decimal points
@@ -131,7 +139,7 @@ export function formatDate(cell: CellString) {
 		month: 'short'
 	})
 
-	return <div className="text-right">{date}</div>
+	return date
 }
 
 // Format a string

--- a/pages/ipos/[year].tsx
+++ b/pages/ipos/[year].tsx
@@ -33,7 +33,6 @@ const query: TableDynamic = {
 }
 
 export default function IpoYear(props: Props) {
-	console.log(props.data)
 	const { year } = props
 
 	const title =
@@ -66,7 +65,7 @@ export default function IpoYear(props: Props) {
 							</div>
 							<TableContextProvider
 								value={{
-									type: 'stocks',
+									type: 'histip',
 									tableId: 'ipos-recent',
 									title: props.data.length + ' IPOs',
 									fixed: {
@@ -122,7 +121,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
 	ssrQuery.filters = [ssrFilter]
 
 	// Fetch the data
-	const response = await getSelect(ssrQuery, 'stocks', true, extras)
+	const response = await getSelect(ssrQuery, 'histip', true, extras)
 	response.props.year = year
 	response.props.info = response.props[extraFn]
 	delete response.props[extraFn]

--- a/pages/ipos/[year].tsx
+++ b/pages/ipos/[year].tsx
@@ -2,8 +2,6 @@ import { GetServerSideProps } from 'next'
 import { IpoRecent, IpoUpcoming } from 'types/Ipos'
 import { News } from 'types/News'
 import { SEO } from 'components/SEO'
-import { getIpoData } from 'functions/apis/callBackEnd'
-import { RecentTable } from 'components/IPOs/RecentTable'
 import { IPONavigation } from 'components/IPOs/IPONavigation/_IPONavigation'
 import { RecentNavigation } from 'components/IPOs/IPONavigation/RecentNavigation'
 import { Breadcrumbs } from 'components/Breadcrumbs/_Breadcrumbs'
@@ -13,18 +11,31 @@ import { NewsWidget } from 'components/News/NewsWidget'
 import { Sidebar1 } from 'components/Ads/AdSense/Sidebar1'
 import { Sidebar2 } from 'components/Ads/AdSense/Sidebar2'
 import { Layout } from 'components/Layout/_Layout'
+import { TableDynamic } from 'components/StockTable/TableTypes'
+import { TableContextProvider } from 'components/StockTable/TableContext'
+import { StockTable } from 'components/StockTable/__StockTable'
+import { getSelect } from 'functions/apis/getSelect'
 
-interface Props {
+type Props = {
 	year: string
-	data: {
-		info: string
-		data: IpoRecent[]
-	}
-	news: News[]
-	upcoming: IpoUpcoming[]
+	data: IpoRecent[]
+	info: string
+	getIpoNewsMin: News[]
+	getIpoCalendarDataMin: IpoUpcoming[]
 }
 
-export const IpoYear = ({ year, data, news, upcoming }: Props) => {
+// the initial config for the select endpoint to fetch data
+const query: TableDynamic = {
+	main: 'ipoDate',
+	sort: [{ id: 'ipoDate', desc: true }],
+	sortDirection: 'asc',
+	columns: ['s', 'n', 'ipp', 'ippc', 'ipr']
+}
+
+export default function IpoYear(props: Props) {
+	console.log(props.data)
+	const { year } = props
+
 	const title =
 		year === '2022'
 			? 'All 2022 IPOs (so far)'
@@ -51,16 +62,42 @@ export const IpoYear = ({ year, data, news, upcoming }: Props) => {
 						<div>
 							<RecentNavigation path={year} />
 							<div className="mt-4 mb-2 lg:mb-3">
-								<InfoBox text={data.info} />
+								<InfoBox text={props.info} />
 							</div>
-							<RecentTable rawdata={data.data} />
+							<TableContextProvider
+								value={{
+									type: 'stocks',
+									tableId: 'ipos-recent',
+									title: props.data.length + ' IPOs',
+									fixed: {
+										defaultSort: query.sort,
+										controls: {
+											filter: true,
+											export: true,
+											columns: true
+										},
+										excludeColumns: ['ch3y', 'ch5y'],
+										columnOrder: [
+											'ipoDate',
+											's',
+											'n',
+											'ipp',
+											'ippc',
+											'ipr'
+										]
+									},
+									dynamic: query
+								}}
+							>
+								<StockTable _data={props.data} />
+							</TableContextProvider>
 						</div>
 						<aside className="flex flex-col space-y-10 pt-6">
-							<CalendarTableMin upcoming={upcoming} />
+							<CalendarTableMin upcoming={props.getIpoCalendarDataMin} />
 							<Sidebar1 />
 							<NewsWidget
 								title="IPO News"
-								news={news}
+								news={props.getIpoNewsMin}
 								button={{
 									text: 'More IPO News',
 									url: '/ipos/news/'
@@ -75,27 +112,22 @@ export const IpoYear = ({ year, data, news, upcoming }: Props) => {
 	)
 }
 
-export default IpoYear
-
 export const getServerSideProps: GetServerSideProps = async context => {
+	// Assemble the SSR request
 	const year = context?.params?.year as string
+	let extraFn = 'getIpoInfo' + year
+	let extras = ['getIpoCalendarDataMin', 'getIpoNewsMin', extraFn]
+	let ssrFilter = 'ipoDate-year-' + year
+	let ssrQuery = query
+	ssrQuery.filters = [ssrFilter]
 
-	if (year.length !== 4 || Number(year) > 2022 || Number(year) < 2019) {
-		return {
-			notFound: true
-		}
-	}
+	// Fetch the data
+	const response = await getSelect(ssrQuery, 'stocks', true, extras)
+	response.props.year = year
+	response.props.info = response.props[extraFn]
+	delete response.props[extraFn]
 
-	const { data, news, upcoming } = await getIpoData(year)
-
+	// Return the data to the page
 	context.res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate')
-
-	return {
-		props: {
-			year,
-			data,
-			news,
-			upcoming
-		}
-	}
+	return response
 }

--- a/pages/ipos/[year].tsx
+++ b/pages/ipos/[year].tsx
@@ -53,7 +53,7 @@ export default function IpoYear(props: Props) {
 				canonical={`/ipos/${year}/`}
 			/>
 			<Layout>
-				<div className="contain">
+				<div className="contain ipos-recent">
 					<Breadcrumbs url={`/ipos/${year}/`} />
 					<h1 className="hh1">All {year} IPOs</h1>
 					<IPONavigation path="" />

--- a/pages/ipos/[year].tsx
+++ b/pages/ipos/[year].tsx
@@ -66,7 +66,7 @@ export default function IpoYear(props: Props) {
 							<TableContextProvider
 								value={{
 									type: 'histip',
-									tableId: 'ipos-recent',
+									tableId: 'ipos-' + year,
 									title: props.data.length + ' IPOs',
 									fixed: {
 										defaultSort: query.sort,
@@ -85,7 +85,10 @@ export default function IpoYear(props: Props) {
 											'ipr'
 										]
 									},
-									dynamic: query
+									dynamic: {
+										...query,
+										filters: ['ipoDate-year-' + year]
+									}
 								}}
 							>
 								<StockTable _data={props.data} />
@@ -116,9 +119,8 @@ export const getServerSideProps: GetServerSideProps = async context => {
 	const year = context?.params?.year as string
 	let extraFn = 'getIpoInfo' + year
 	let extras = ['getIpoCalendarDataMin', 'getIpoNewsMin', extraFn]
-	let ssrFilter = 'ipoDate-year-' + year
 	let ssrQuery = query
-	ssrQuery.filters = [ssrFilter]
+	ssrQuery.filters = ['ipoDate-year-' + year]
 
 	// Fetch the data
 	const response = await getSelect(ssrQuery, 'histip', true, extras)

--- a/pages/ipos/index.tsx
+++ b/pages/ipos/index.tsx
@@ -49,7 +49,7 @@ export default function RecentIpos(props: Props) {
 							<RecentNavigation path="" />
 							<TableContextProvider
 								value={{
-									type: 'stocks',
+									type: 'histip',
 									tableId: 'ipos-recent',
 									title: 'Last 200 IPOs',
 									fixed: {
@@ -97,7 +97,7 @@ export default function RecentIpos(props: Props) {
 
 export const getServerSideProps: GetServerSideProps = async ({ res }) => {
 	let extras = ['getIpoCalendarDataMin', 'getIpoNewsMin']
-	const response = await getSelect(query, 'stocks', true, extras)
+	const response = await getSelect(query, 'histip', true, extras)
 
 	res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate')
 	return response

--- a/pages/ipos/index.tsx
+++ b/pages/ipos/index.tsx
@@ -27,7 +27,7 @@ const query: TableDynamic = {
 	count: 200,
 	sort: [{ id: 'ipoDate', desc: true }],
 	sortDirection: 'asc',
-	columns: ['s', 'n', 'price', 'volume', 'marketCap']
+	columns: ['s', 'n', 'ipp', 'ippc', 'ipr']
 }
 
 export default function RecentIpos(props: Props) {
@@ -39,7 +39,7 @@ export default function RecentIpos(props: Props) {
 				canonical="/ipos/"
 			/>
 			<Layout>
-				<div className="contain">
+				<div className="contain ipos-recent">
 					<Breadcrumbs url="/ipos/" />
 					<h1 className="hh1">Recent IPOs</h1>
 					<IPONavigation path="" />
@@ -64,9 +64,9 @@ export default function RecentIpos(props: Props) {
 											'ipoDate',
 											's',
 											'n',
-											'price',
-											'volume',
-											'marketCap'
+											'ipp',
+											'ippc',
+											'ipr'
 										]
 									},
 									dynamic: query

--- a/pages/markets/active.tsx
+++ b/pages/markets/active.tsx
@@ -11,8 +11,7 @@ import { TableDynamic } from 'components/StockTable/TableTypes'
 // the page's config and settings
 const page: PageConfig = {
 	path: '/markets/active/',
-	title: 'Active Today',
-	parentTitle: 'Most Active Stocks',
+	pageTitle: 'Most Active Stocks',
 	active: 'active',
 	metaTitle: "Today's Most Active Stocks",
 	metaDescription:
@@ -41,6 +40,7 @@ export default function ActivePage({ data, updated }: Props) {
 				<TableContextProvider
 					value={{
 						type: 'stocks',
+						title: 'Active Today',
 						tableId: 'active',
 						fixed: {
 							defaultSort: query.sort,

--- a/pages/markets/active.tsx
+++ b/pages/markets/active.tsx
@@ -30,12 +30,12 @@ const query: TableDynamic = {
 
 type Props = {
 	data: any[]
-	updated: TableTimestamp
+	tradingTimestamps: TableTimestamp
 }
 
-export default function ActivePage({ data, updated }: Props) {
+export default function ActivePage({ data, tradingTimestamps }: Props) {
 	return (
-		<PageContextProvider value={{ page, updated }}>
+		<PageContextProvider value={{ page, updated: tradingTimestamps }}>
 			<MarketsLayout>
 				<TableContextProvider
 					value={{
@@ -64,7 +64,8 @@ export default function ActivePage({ data, updated }: Props) {
 }
 
 export const getServerSideProps: GetServerSideProps = async context => {
-	const data = await getSelect(query, 'stocks', true)
+	let extras = ['tradingTimestamps']
+	const data = await getSelect(query, 'stocks', true, extras)
 	context.res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate')
 	return data
 }

--- a/pages/markets/gainers.tsx
+++ b/pages/markets/gainers.tsx
@@ -11,8 +11,7 @@ import { TableDynamic } from 'components/StockTable/TableTypes'
 // the page's config and settings
 const page: PageConfig = {
 	path: '/markets/gainers/',
-	title: 'Gainers Today',
-	parentTitle: 'Top Stock Gainers',
+	pageTitle: 'Top Stock Gainers',
 	active: 'gainers',
 	metaTitle: "Today's Top Stock Gainers",
 	metaDescription:
@@ -41,6 +40,7 @@ export default function GainersPage({ data, updated }: Props) {
 				<TableContextProvider
 					value={{
 						type: 'stocks',
+						title: 'Gainers Today',
 						tableId: 'gainers',
 						fixed: {
 							defaultSort: query.sort,

--- a/pages/markets/gainers.tsx
+++ b/pages/markets/gainers.tsx
@@ -30,12 +30,12 @@ const query: TableDynamic = {
 
 type Props = {
 	data: any[]
-	updated: TableTimestamp
+	tradingTimestamps: TableTimestamp
 }
 
-export default function GainersPage({ data, updated }: Props) {
+export default function GainersPage({ data, tradingTimestamps }: Props) {
 	return (
-		<PageContextProvider value={{ page, updated }}>
+		<PageContextProvider value={{ page, updated: tradingTimestamps }}>
 			<MarketsLayout>
 				<TableContextProvider
 					value={{
@@ -64,7 +64,8 @@ export default function GainersPage({ data, updated }: Props) {
 }
 
 export const getServerSideProps: GetServerSideProps = async context => {
-	const data = await getSelect(query, 'stocks', true)
+	let extras = ['tradingTimestamps']
+	const data = await getSelect(query, 'stocks', true, extras)
 	context.res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate')
 	return data
 }

--- a/pages/markets/losers.tsx
+++ b/pages/markets/losers.tsx
@@ -30,12 +30,12 @@ const query: TableDynamic = {
 
 type Props = {
 	data: any[]
-	updated: TableTimestamp
+	tradingTimestamps: TableTimestamp
 }
 
-export default function LosersPage({ data, updated }: Props) {
+export default function LosersPage({ data, tradingTimestamps }: Props) {
 	return (
-		<PageContextProvider value={{ page, updated }}>
+		<PageContextProvider value={{ page, updated: tradingTimestamps }}>
 			<MarketsLayout>
 				<TableContextProvider
 					value={{
@@ -64,7 +64,8 @@ export default function LosersPage({ data, updated }: Props) {
 }
 
 export const getServerSideProps: GetServerSideProps = async context => {
-	const data = await getSelect(query, 'stocks', true)
+	let extras = ['tradingTimestamps']
+	const data = await getSelect(query, 'stocks', true, extras)
 	context.res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate')
 	return data
 }

--- a/pages/markets/losers.tsx
+++ b/pages/markets/losers.tsx
@@ -11,8 +11,7 @@ import { TableDynamic } from 'components/StockTable/TableTypes'
 // the page's config and settings
 const page: PageConfig = {
 	path: '/markets/losers/',
-	title: 'Losers Today',
-	parentTitle: 'Top Stock Losers',
+	pageTitle: 'Top Stock Losers',
 	active: 'losers',
 	metaTitle: "Today's Top Stock Losers",
 	metaDescription:
@@ -41,6 +40,7 @@ export default function LosersPage({ data, updated }: Props) {
 				<TableContextProvider
 					value={{
 						type: 'stocks',
+						title: 'Losers Today',
 						tableId: 'losers',
 						fixed: {
 							defaultSort: query.sort,

--- a/pages/markets/premarket/index.tsx
+++ b/pages/markets/premarket/index.tsx
@@ -30,12 +30,12 @@ const query: TableDynamic = {
 
 type Props = {
 	data: any[]
-	updated: TableTimestamp
+	tradingTimestamps: TableTimestamp
 }
 
-export default function PreMarket({ data, updated }: Props) {
+export default function PreMarket({ data, tradingTimestamps }: Props) {
 	return (
-		<PageContextProvider value={{ page, updated }}>
+		<PageContextProvider value={{ page, updated: tradingTimestamps }}>
 			<MarketsLayout>
 				<TableContextProvider
 					value={{
@@ -65,7 +65,8 @@ export default function PreMarket({ data, updated }: Props) {
 }
 
 export const getServerSideProps: GetServerSideProps = async context => {
-	const data = await getSelect(query, 'stocks', true)
+	let extras = ['tradingTimestamps']
+	const data = await getSelect(query, 'stocks', true, extras)
 	context.res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate')
 	return data
 }

--- a/pages/markets/premarket/index.tsx
+++ b/pages/markets/premarket/index.tsx
@@ -11,8 +11,7 @@ import { TableDynamic } from 'components/StockTable/TableTypes'
 // the page's config and settings
 const page: PageConfig = {
 	path: '/markets/premarket/',
-	title: 'Top Gainers',
-	parentTitle: 'Premarket Movers',
+	pageTitle: 'Premarket Movers',
 	active: 'premarket',
 	metaTitle: "Today's Premarket Stock Movers",
 	metaDescription:
@@ -41,6 +40,7 @@ export default function PreMarket({ data, updated }: Props) {
 				<TableContextProvider
 					value={{
 						type: 'stocks',
+						title: 'Top Gainers',
 						tableId: 'premarket',
 						fixed: {
 							defaultSort: query.sort,

--- a/styles/features/controls/_controls.css
+++ b/styles/features/controls/_controls.css
@@ -73,4 +73,12 @@
 	.controls-icon {
 		@apply -mr-1 ml-1 xs:ml-2 w-5 h-5;
 	}
+
+	.controls-export {
+		@apply hidden md:block;
+	}
+
+	.ipos-recent .controls-export {
+		@apply block;
+	}
 }

--- a/styles/features/symbol-table/stock-table.css
+++ b/styles/features/symbol-table/stock-table.css
@@ -4,6 +4,10 @@
 */
 
 @layer components {
+	.stock-table a {
+		@apply py-0.5;
+	}
+
 	.stock-table tr > * {
 		@apply whitespace-nowrap;
 	}
@@ -12,12 +16,17 @@
 		@apply font-semibold;
 	}
 
-	.stock-table tr th .head-left {
+	.stock-table tr th .head-left,
+	.stock-table tr th:first-child .head-right {
 		@apply inline-flex flex-row items-center;
 	}
 
-	.stock-table tr th .head-right {
+	.stock-table tr th:not(:first-child) .head-right {
 		@apply flex flex-row items-center justify-end;
+	}
+
+	.stock-table tr > td:first-child {
+		@apply flex flex-row justify-start;
 	}
 
 	.stock-table .string-left {

--- a/styles/features/symbol-table/stock-table.css
+++ b/styles/features/symbol-table/stock-table.css
@@ -5,7 +5,7 @@
 
 @layer components {
 	.stock-table a {
-		@apply py-0.5;
+		@apply py-px;
 	}
 
 	.stock-table tr > * {
@@ -23,10 +23,6 @@
 
 	.stock-table tr th:not(:first-child) .head-right {
 		@apply flex flex-row items-center justify-end;
-	}
-
-	.stock-table tr > td:first-child {
-		@apply flex flex-row justify-start;
 	}
 
 	.stock-table .string-left {

--- a/types/DataId.ts
+++ b/types/DataId.ts
@@ -1,16 +1,29 @@
 // All possible data points
 export type DataId =
+	// > Symbol and name always included
 	| 's' // Symbol
 	| 'n' // Name
-	| 'marketCap' // Market Cap
+	// > Quotes - regular trading hours
 	| 'price' // Stock Price
 	| 'chg' // Stock Price Change
 	| 'change' // Price Change 1D
 	| 'volume' // Volume
 	| 'close' // Previous Close
+	// > Quotes - premarket
 	| 'premarketPrice' // Pre-Market Price
 	| 'premarketChange' // Pre-Market Change
 	| 'premarketChangePercent' // Pre-Market Percentage Change
+	// > IPO details
+	// TODO add to screener
+	| 'ipoDate' // IPO Date
+	| 'ipp' // IPO Price
+	| 'ippc' // IPO Price
+	| 'ipr' // IPO Return
+	// TODO open price
+	// TODO return from open
+	// TODO ipo deal size
+	// ...
+	| 'marketCap' // Market Cap
 	| 'enterpriseValue' // Enterprise Value
 	| 'industry' // Industry
 	| 'peRatio' // PE Ratio
@@ -32,7 +45,6 @@ export type DataId =
 	| 'country' // Country
 	| 'employees' // Employees
 	| 'founded' // Founded
-	| 'ipoDate' // IPO Date
 	| 'revenue' // Revenue
 	| 'revenueGrowth' // Revenue Growth
 	| 'revenueGrowthQ' // Revenue Growth (Quarterly)

--- a/types/PageConfig.ts
+++ b/types/PageConfig.ts
@@ -1,7 +1,6 @@
 export type PageConfig = {
 	path: string
-	title: string
-	parentTitle?: string
+	pageTitle?: string
 	active?: string
 	metaTitle: string
 	metaDescription: string

--- a/types/Tables.ts
+++ b/types/Tables.ts
@@ -10,6 +10,10 @@ export type CellNumber = {
 	}
 }
 
+// The type of index to select for the stock table
+// The narrower/smaller, the better the performance
+export type IndexType = 'stocks' | 'etf' | 'histip'
+
 // Names of functions that format table cells
 export type FormatFunction =
 	| 'linkSymbol'

--- a/types/Tables.ts
+++ b/types/Tables.ts
@@ -15,6 +15,7 @@ export type FormatFunction =
 	| 'linkSymbol'
 	| 'linkName'
 	| 'format2dec'
+	| 'price'
 	| 'integer'
 	| 'formatPercentage'
 	| 'colorPercentage'

--- a/types/Tables.ts
+++ b/types/Tables.ts
@@ -10,8 +10,10 @@ export type CellNumber = {
 	}
 }
 
+// Names of functions that format table cells
 export type FormatFunction =
 	| 'linkSymbol'
+	| 'linkName'
 	| 'format2dec'
 	| 'integer'
 	| 'formatPercentage'
@@ -19,6 +21,13 @@ export type FormatFunction =
 	| 'abbreviate'
 	| 'formatDate'
 	| 'string'
+
+// Names of functions that perform sorting of table rows
+export type SortFunction =
+	| 'dateSort'
+	| 'priceSort'
+	| 'stringNullFix'
+	| 'numberNullFix'
 
 /**
  * Timestamps for a stock table


### PR DESCRIPTION
The stock tables are now used to generate the recent IPOs and 2019-2022 IPO pages. This adds a "Columns" dropdown where people can select the data points to show. It also persists the sorted state when clicking from and back to the page. The state is also stored in localStorage.