### PR TITLE
Keep zero values at start of data array

### DIFF
--- a/components/FinancialTable/HoverChart.tsx
+++ b/components/FinancialTable/HoverChart.tsx
@@ -146,17 +146,6 @@ export const HoverChart = ({
 		}
 	}
 
-	// Cut zero values from start of data array
-	const ylength = yaxis.length
-	for (let i = 0; i < ylength; i++) {
-		if (!yaxis[0]) {
-			yaxis.shift()
-			xaxis.shift()
-		} else {
-			break
-		}
-	}
-
 	const ymin = yaxis[0]
 	const ymax = yaxis[yaxis.length - 1]
 


### PR DESCRIPTION
After using the site for a while, I noticed that zero data gets removed. This is a bit counterintuitive when quickly comparing between many charts, since the user expects to see a visual history of the financial data, zeros included. 

![image](https://user-images.githubusercontent.com/8009732/158527579-2e1df12d-852b-4012-8461-80a603235c5e.png)

I propose to keep the zero values, as it makes parsing what the financial data represents a lot easier (in this case, a company has recently begun to acquire new debt).

(Love the site, I'm a paid subscriber)